### PR TITLE
increase max_query_terms to 1024

### DIFF
--- a/src/graphql/queries/Search.js
+++ b/src/graphql/queries/Search.js
@@ -42,9 +42,9 @@ export default {
       client.msearch({
         body: [
           { index: 'rumors', type: 'basic' },
-          { query: { more_like_this: { fields: ['text'], like: text, min_term_freq: 1, min_doc_freq: 1 } } },
+          { query: { more_like_this: { fields: ['text'], like: text, min_term_freq: 1, min_doc_freq: 1,max_query_terms:1024 } } },
           { index: 'answers', type: 'basic' },
-          { query: { more_like_this: { fields: ['versions.text'], like: text, min_term_freq: 1, min_doc_freq: 1 } } },
+          { query: { more_like_this: { fields: ['versions.text'], like: text, min_term_freq: 1, min_doc_freq: 1,max_query_terms:1024 } } },
         ],
       }),
       findInCrawled ?


### PR DESCRIPTION
max_query_terms 預設值 25 太小了，先一次開到 1024 ~
跑 validate:sameDoc 的結果：
---- Summary ----
132/134 correct
98.51 % correct.