### PR TITLE
Adds field createdAt and updatedAt to ReplyConnection

### DIFF
--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -44,7 +44,9 @@ const Article = new GraphQLObjectType({
       },
       resolve: async ({ replyConnectionIds = [] }, { status }, { loaders }) => {
         const replyConnections = await loaders.docLoader.loadMany(
-          replyConnectionIds.map(id => ({ index: 'replyconnections', id }))
+          replyConnectionIds
+            .reverse() // latest inserted replyConnection goes first
+            .map(id => ({ index: 'replyconnections', id }))
         );
 
         if (!status) return replyConnections;

--- a/src/graphql/models/ReplyConnection.js
+++ b/src/graphql/models/ReplyConnection.js
@@ -65,5 +65,8 @@ export default new GraphQLObjectType({
     status: {
       type: GraphQLString,
     },
+
+    createdAt: { type: GraphQLString },
+    updatedAt: { type: GraphQLString },
   }),
 });

--- a/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
+++ b/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
@@ -18,6 +18,8 @@ export default {
   '/replyconnections/basic/foo-bar': {
     replyId: 'bar',
     status: 'NORMAL',
+    createdAt: '2015-01-01T12:10:30Z',
+    updatedAt: '2015-01-02T12:10:30Z',
   },
   '/replyconnections/basic/foo2-bar2': {
     replyId: 'bar2',

--- a/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
+++ b/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
@@ -17,6 +17,8 @@ describe('GetReplyAndGetArticle', () => {
             id
             status
             canUpdateStatus
+            createdAt
+            updatedAt
             reply {
               versions {
                 text

--- a/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
@@ -34,6 +34,7 @@ Object {
       "replyConnections": Array [
         Object {
           "canUpdateStatus": false,
+          "createdAt": "2015-01-01T12:10:30Z",
           "id": "foo-bar",
           "reply": Object {
             "versions": Array [
@@ -45,6 +46,7 @@ Object {
             ],
           },
           "status": "NORMAL",
+          "updatedAt": "2015-01-02T12:10:30Z",
         },
       ],
       "replyCount": 1,


### PR DESCRIPTION
Sorts article's replyConnection by createdAt field by default, required by cofacts/rumors-site#29

Also provide necessary fields so that clients can sort by themselves.