### PR TITLE
Add status filter to reply object type’s replyconnection field

### DIFF
--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -15,6 +15,7 @@ import {
   createSortType,
   createConnectionType,
   assertUser,
+  filterReplyConnectionsByStatus,
 } from 'graphql/util';
 
 import ArticleReference from 'graphql/models/ArticleReference';
@@ -49,12 +50,7 @@ const Article = new GraphQLObjectType({
             .map(id => ({ index: 'replyconnections', id }))
         );
 
-        if (!status) return replyConnections;
-        return replyConnections.filter(conn => {
-          if (status !== 'NORMAL') return conn.status === status;
-
-          return conn.status === undefined || conn.status === 'NORMAL';
-        });
+        return filterReplyConnectionsByStatus(replyConnections, status);
       },
     },
     replyRequestCount: {

--- a/src/graphql/models/Reply.js
+++ b/src/graphql/models/Reply.js
@@ -5,6 +5,8 @@ import {
   GraphQLInt,
 } from 'graphql';
 
+import { filterReplyConnectionsByStatus } from 'graphql/util';
+import ReplyConnectionStatusEnum from './ReplyConnectionStatusEnum';
 import ReplyConnection from './ReplyConnection';
 import ReplyVersion from './ReplyVersion';
 
@@ -21,8 +23,18 @@ const Reply = new GraphQLObjectType({
     },
     replyConnections: {
       type: new GraphQLList(ReplyConnection),
-      resolve: ({ id }, args, { loaders }) =>
-        loaders.replyConnectionsByReplyIdLoader.load(id),
+      args: {
+        status: {
+          type: ReplyConnectionStatusEnum,
+          description: 'When specified, returns only reply connections with the specified status',
+        },
+      },
+      resolve: async ({ id }, { status }, { loaders }) => {
+        const replyConnections = await loaders.replyConnectionsByReplyIdLoader.load(
+          id
+        );
+        return filterReplyConnectionsByStatus(replyConnections, status);
+      },
     },
   }),
 });

--- a/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
+++ b/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
@@ -34,6 +34,9 @@ export default {
   '/replies/basic/bar': {
     versions: [{ text: 'bar', reference: 'barbar', type: 'NOT_ARTICLE' }],
   },
+  '/replies/basic/bar2': {
+    versions: [{ text: 'bar2', reference: 'barbar2', type: 'NOT_ARTICLE' }],
+  },
   '/replyrequests/basic/articleTest1': {
     userId: 'fakeUser',
     from: 'LINE',

--- a/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
+++ b/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
@@ -38,23 +38,9 @@ describe('GetReplyAndGetArticle', () => {
       expect(
         await gql`{
           GetArticle(id: "foo3") {
-            replyConnections { id }
-          }
-        }`({}, { userId: 'fakeUser', from: 'LINE' })
-      ).toMatchSnapshot();
-
-      expect(
-        await gql`{
-          GetArticle(id: "foo3") {
-            replyConnections(status: NORMAL) { id }
-          }
-        }`({}, { userId: 'fakeUser', from: 'LINE' })
-      ).toMatchSnapshot();
-
-      expect(
-        await gql`{
-          GetArticle(id: "foo3") {
-            replyConnections(status: DELETED) { id }
+            replyConnections { id, status }
+            normalReplies: replyConnections(status: NORMAL) { id, status }
+            deletedReplies: replyConnections(status: DELETED) { id, status }
           }
         }`({}, { userId: 'fakeUser', from: 'LINE' })
       ).toMatchSnapshot();
@@ -133,6 +119,18 @@ describe('GetReplyAndGetArticle', () => {
               text
             }
           }
+        }
+      }`()
+      ).toMatchSnapshot();
+    });
+
+    it('should get allow filtering replyConnections', async () => {
+      expect(
+        await gql`{
+        GetReply(id: "bar2") {
+          replyConnections { id, status }
+          normalReplies: replyConnections(status: NORMAL) { id, status }
+          deletedReplies: replyConnections(status: DELETED) { id, status }
         }
       }`()
       ).toMatchSnapshot();

--- a/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
@@ -2,40 +2,26 @@ exports[`GetReplyAndGetArticle GetArticle should allow filtering replyConnection
 Object {
   "data": Object {
     "GetArticle": Object {
+      "deletedReplies": Array [
+        Object {
+          "id": "foo3-bar2",
+          "status": "DELETED",
+        },
+      ],
+      "normalReplies": Array [
+        Object {
+          "id": "foo3-fofo",
+          "status": "NORMAL",
+        },
+      ],
       "replyConnections": Array [
         Object {
           "id": "foo3-bar2",
+          "status": "DELETED",
         },
         Object {
           "id": "foo3-fofo",
-        },
-      ],
-    },
-  },
-}
-`;
-
-exports[`GetReplyAndGetArticle GetArticle should allow filtering replyConnections 2`] = `
-Object {
-  "data": Object {
-    "GetArticle": Object {
-      "replyConnections": Array [
-        Object {
-          "id": "foo3-fofo",
-        },
-      ],
-    },
-  },
-}
-`;
-
-exports[`GetReplyAndGetArticle GetArticle should allow filtering replyConnections 3`] = `
-Object {
-  "data": Object {
-    "GetArticle": Object {
-      "replyConnections": Array [
-        Object {
-          "id": "foo3-bar2",
+          "status": "NORMAL",
         },
       ],
     },
@@ -74,6 +60,37 @@ Object {
       "replyRequestCount": 1,
       "requestedForReply": true,
       "text": "Lorum ipsum",
+    },
+  },
+}
+`;
+
+exports[`GetReplyAndGetArticle GetReply should get allow filtering replyConnections 1`] = `
+Object {
+  "data": Object {
+    "GetReply": Object {
+      "deletedReplies": Array [
+        Object {
+          "id": "foo3-bar2",
+          "status": "DELETED",
+        },
+      ],
+      "normalReplies": Array [
+        Object {
+          "id": "foo2-bar2",
+          "status": "NORMAL",
+        },
+      ],
+      "replyConnections": Array [
+        Object {
+          "id": "foo2-bar2",
+          "status": "NORMAL",
+        },
+        Object {
+          "id": "foo3-bar2",
+          "status": "DELETED",
+        },
+      ],
     },
   },
 }

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -280,3 +280,15 @@ export function assertUser({ userId, from }) {
     );
   }
 }
+
+export function filterReplyConnectionsByStatus(replyConnections, status) {
+  if (!status) return replyConnections;
+
+  // If a replyConnection does not have status, it is considered "NORMAL".
+  //
+  return replyConnections.filter(conn => {
+    if (status !== 'NORMAL') return conn.status === status;
+
+    return conn.status === undefined || conn.status === 'NORMAL';
+  });
+}


### PR DESCRIPTION
Currently `Article`'s `replyconnection` field accepts "status" argument to return only deleted or not deleted replyconnections.

This PR makes `Reply` also support so.