### PR TITLE
selfOnly should be preserved for logged-in users

### DIFF
--- a/src/graphql/queries/ListReplies.js
+++ b/src/graphql/queries/ListReplies.js
@@ -98,6 +98,7 @@ export default {
     }
 
     if (filter.selfOnly) {
+      if (!userId) throw new Error('selfOnly can be set only after log in');
       body.query.bool.filter.push(
         { term: { 'versions.userId': userId } },
         { term: { 'versions.from': from } }

--- a/src/graphql/queries/__tests__/ListReplies.js
+++ b/src/graphql/queries/__tests__/ListReplies.js
@@ -142,5 +142,24 @@ describe('ListReplies', () => {
     ).toMatchSnapshot();
   });
 
+  it('handles selfOnly filter properly if not logged in', async () => {
+    expect(
+      await gql`{
+        ListReplies(filter: {selfOnly: true}) {
+          edges {
+            node {
+              id
+            }
+          }
+          totalCount
+          pageInfo {
+            firstCursor
+            lastCursor
+          }
+        }
+      }`()
+    ).toMatchSnapshot();
+  });
+
   afterAll(() => unloadFixtures(fixtures));
 });

--- a/src/graphql/queries/__tests__/__snapshots__/ListReplies.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListReplies.js.snap
@@ -66,6 +66,17 @@ Object {
 }
 `;
 
+exports[`ListReplies handles selfOnly filter properly if not logged in 1`] = `
+Object {
+  "data": Object {
+    "ListReplies": null,
+  },
+  "errors": Array [
+    [GraphQLError: selfOnly can be set only after log in],
+  ],
+}
+`;
+
 exports[`ListReplies lists all replies 1`] = `
 Object {
   "data": Object {


### PR DESCRIPTION
The current error message is not informative when an user is not logged in and selfOnly is specified.
![2017-08-20 11 01 14](https://user-images.githubusercontent.com/108608/29495959-8155d3cc-85fb-11e7-9c2a-81bef103b1bc.png)

This PR gives clear error message for such situation.