### PR TITLE
Check duplications before creating new article on CreateArticle API

### DIFF
--- a/src/graphql/mutations/CreateArticle.js
+++ b/src/graphql/mutations/CreateArticle.js
@@ -6,6 +6,15 @@ import { ArticleReferenceInput } from 'graphql/models/ArticleReference';
 import MutationResult from 'graphql/models/MutationResult';
 import { createReplyRequest } from './CreateReplyRequest';
 
+/**
+ * Creates a new article in ElasticSearch
+ *
+ * @param {String} param.text
+ * @param {String} param.reference
+ * @param {String} param.userId
+ * @param {String} param.from
+ * @returns {String} the new article's ID
+ */
 async function createNewArticle({ text, reference, userId, from }) {
   const now = new Date().toISOString();
   reference.createdAt = now;
@@ -57,10 +66,13 @@ export default {
       },
     });
 
+    // Don't create new articles if a hit is found;
+    // return the existing article's ID instead
     const articleId = searchResult.hits.total > 0
       ? searchResult.hits.hits[0]._id
       : await createNewArticle({ text, reference, userId, from });
 
+    // No matter we created an article or not, we should always add replyRequest.
     await createReplyRequest({ articleId, userId, from });
 
     return { id: articleId };

--- a/src/graphql/mutations/__fixtures__/CreateArticle.js
+++ b/src/graphql/mutations/__fixtures__/CreateArticle.js
@@ -1,0 +1,12 @@
+export default {
+  '/articles/basic/existing-but-different': {
+    text: 'I think I exist I am',
+    replyRequestIds: [],
+    references: [{ type: 'LINE' }],
+  },
+  '/articles/basic/existing': {
+    text: 'I think I am I exist',
+    replyRequestIds: [],
+    references: [{ type: 'LINE' }],
+  },
+};

--- a/src/graphql/mutations/__tests__/CreateArticle.js
+++ b/src/graphql/mutations/__tests__/CreateArticle.js
@@ -79,7 +79,8 @@ describe('CreateArticle', () => {
     MockDate.reset();
     expect(errors).toBeUndefined();
 
-    // Expects no new article is created
+    // Expects no new article is created,
+    // and it returns the existing ID
     expect(data.CreateArticle.id).toBe('existing');
 
     const { _source: article } = await client.get({

--- a/src/graphql/mutations/__tests__/CreateArticle.js
+++ b/src/graphql/mutations/__tests__/CreateArticle.js
@@ -5,6 +5,7 @@ import MockDate from 'mockdate';
 
 describe('CreateArticle', () => {
   it('creates articles', async () => {
+  it('creates articles and a reply request', async () => {
     MockDate.set(1485593157011);
     const { data, errors } = await gql`
       mutation(
@@ -29,17 +30,17 @@ describe('CreateArticle', () => {
 
     expect(errors).toBeUndefined();
 
-    const doc = await client.get({
+    const { _source: article } = await client.get({
       index: 'articles',
       type: 'basic',
       id: data.CreateArticle.id,
     });
-    expect(doc._source.replyRequestIds).toHaveLength(1);
+    expect(article.replyRequestIds).toHaveLength(1);
 
-    delete doc._id; // delete auto-generated id from being snapshot
-    delete doc._source.replyRequestIds;
+    // delete auto-generated id from being snapshot
+    delete article.replyRequestIds;
 
-    expect(doc).toMatchSnapshot();
+    expect(article).toMatchSnapshot();
 
     // Cleanup
     await client.delete({

--- a/src/graphql/mutations/__tests__/CreateArticle.js
+++ b/src/graphql/mutations/__tests__/CreateArticle.js
@@ -1,10 +1,12 @@
 import gql from 'util/GraphQL';
+import { loadFixtures, unloadFixtures } from 'util/fixtures';
 import client from 'util/client';
-
 import MockDate from 'mockdate';
+import fixtures from '../__fixtures__/CreateArticle';
 
 describe('CreateArticle', () => {
-  it('creates articles', async () => {
+  beforeAll(() => loadFixtures(fixtures));
+
   it('creates articles and a reply request', async () => {
     MockDate.set(1485593157011);
     const { data, errors } = await gql`
@@ -49,4 +51,61 @@ describe('CreateArticle', () => {
       id: data.CreateArticle.id,
     });
   });
+
+  it('avoids creating duplicated articles and adds replyRequests automatically', async () => {
+    MockDate.set(1485593157011);
+    const existingArticle = fixtures['/articles/basic/existing'];
+    const userId = 'test';
+
+    const { data, errors } = await gql`
+      mutation(
+        $text: String!
+        $reference: ArticleReferenceInput!
+      ) {
+        CreateArticle(
+          text: $text
+          reference: $reference
+        ) {
+          id
+        }
+      }
+    `(
+      {
+        text: existingArticle.text,
+        reference: existingArticle.references[0],
+      },
+      { userId, from: 'foo' }
+    );
+    MockDate.reset();
+    expect(errors).toBeUndefined();
+
+    // Expects no new article is created
+    expect(data.CreateArticle.id).toBe('existing');
+
+    const { _source: article } = await client.get({
+      index: 'articles',
+      type: 'basic',
+      id: 'existing',
+    });
+
+    // Expects new replyRequestId is created
+    expect(article.replyRequestIds).toHaveLength(1);
+
+    const { _source: replyRequest } = await client.get({
+      index: 'replyrequests',
+      type: 'basic',
+      id: article.replyRequestIds[0],
+    });
+
+    expect(replyRequest.userId).toBe(userId);
+
+    // Cleanup
+    await client.delete({
+      index: 'replyrequests',
+      type: 'basic',
+      id: article.replyRequestIds[0],
+    });
+  });
+
+  afterAll(() => unloadFixtures(fixtures));
 });

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateArticle.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateArticle.js.snap
@@ -1,22 +1,16 @@
-exports[`CreateArticle creates articles 1`] = `
+exports[`CreateArticle creates articles and a reply request 1`] = `
 Object {
-  "_index": "articles",
-  "_source": Object {
-    "createdAt": "2017-01-28T08:45:57.011Z",
-    "from": "foo",
-    "references": Array [
-      Object {
-        "createdAt": "2017-01-28T08:45:57.011Z",
-        "type": "LINE",
-      },
-    ],
-    "replyConnectionIds": Array [],
-    "text": "FOO FOO",
-    "updatedAt": "2017-01-28T08:45:57.011Z",
-    "userId": "test",
-  },
-  "_type": "basic",
-  "_version": 2,
-  "found": true,
+  "createdAt": "2017-01-28T08:45:57.011Z",
+  "from": "foo",
+  "references": Array [
+    Object {
+      "createdAt": "2017-01-28T08:45:57.011Z",
+      "type": "LINE",
+    },
+  ],
+  "replyConnectionIds": Array [],
+  "text": "FOO FOO",
+  "updatedAt": "2017-01-28T08:45:57.011Z",
+  "userId": "test",
 }
 `;


### PR DESCRIPTION
This prevents duplicate articles being sent into the database.
See https://github.com/cofacts/rumors-line-bot/issues/41 for the real-world cases we'd like to prevent.

Fixes #52 , https://github.com/cofacts/rumors-line-bot/issues/41