### PR TITLE
Add reason field to ReplyRequests

### DIFF
--- a/src/graphql/models/FeedbackVote.js
+++ b/src/graphql/models/FeedbackVote.js
@@ -1,0 +1,10 @@
+import { GraphQLEnumType } from 'graphql';
+
+export default new GraphQLEnumType({
+  name: 'FeedbackVote',
+  values: {
+    UPVOTE: { value: 1 },
+    NEUTRAL: { value: 0 },
+    DOWNVOTE: { value: -1 },
+  },
+});

--- a/src/graphql/models/ReplyRequest.js
+++ b/src/graphql/models/ReplyRequest.js
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLString } from 'graphql';
+import { GraphQLObjectType, GraphQLString, GraphQLInt } from 'graphql';
 
 export default new GraphQLObjectType({
   name: 'ReplyRequest',
@@ -6,6 +6,25 @@ export default new GraphQLObjectType({
     id: { type: GraphQLString },
     userId: { type: GraphQLString },
     appId: { type: GraphQLString },
+    reason: { type: GraphQLString },
+    feedbackCount: {
+      type: GraphQLInt,
+      resolve({ feedbacks }) {
+        return feedbacks.length;
+      },
+    },
+    positiveFeedbackCount: {
+      type: GraphQLInt,
+      resolve({ feedbacks }) {
+        return feedbacks.filter(fb => fb.score === 1).length;
+      },
+    },
+    negativeFeedbackCount: {
+      type: GraphQLInt,
+      resolve({ feedbacks }) {
+        return feedbacks.filter(fb => fb.score === -1).length;
+      },
+    },
     createdAt: { type: GraphQLString },
     updatedAt: { type: GraphQLString },
   }),

--- a/src/graphql/models/ReplyRequest.js
+++ b/src/graphql/models/ReplyRequest.js
@@ -9,19 +9,19 @@ export default new GraphQLObjectType({
     reason: { type: GraphQLString },
     feedbackCount: {
       type: GraphQLInt,
-      resolve({ feedbacks }) {
+      resolve({ feedbacks = [] }) {
         return feedbacks.length;
       },
     },
     positiveFeedbackCount: {
       type: GraphQLInt,
-      resolve({ feedbacks }) {
+      resolve({ feedbacks = [] }) {
         return feedbacks.filter(fb => fb.score === 1).length;
       },
     },
     negativeFeedbackCount: {
       type: GraphQLInt,
-      resolve({ feedbacks }) {
+      resolve({ feedbacks = [] }) {
         return feedbacks.filter(fb => fb.score === -1).length;
       },
     },

--- a/src/graphql/mutations/CreateArticle.js
+++ b/src/graphql/mutations/CreateArticle.js
@@ -94,8 +94,13 @@ export default {
   args: {
     text: { type: new GraphQLNonNull(GraphQLString) },
     reference: { type: new GraphQLNonNull(ArticleReferenceInput) },
+    reason: {
+      type: new GraphQLNonNull(GraphQLString),
+      description:
+        'The reason why the user want to submit this article. Mandatory for 1st sender',
+    },
   },
-  async resolve(rootValue, { text, reference }, { appId, userId }) {
+  async resolve(rootValue, { text, reference, reason }, { appId, userId }) {
     assertUser({ appId, userId });
 
     const articleId = await createNewArticle({
@@ -105,7 +110,7 @@ export default {
       appId,
     });
 
-    await createReplyRequest({ articleId, userId, appId });
+    await createReplyRequest({ articleId, userId, appId, reason });
 
     return { id: articleId };
   },

--- a/src/graphql/mutations/CreateArticle.js
+++ b/src/graphql/mutations/CreateArticle.js
@@ -95,7 +95,9 @@ export default {
     text: { type: new GraphQLNonNull(GraphQLString) },
     reference: { type: new GraphQLNonNull(ArticleReferenceInput) },
     reason: {
-      type: new GraphQLNonNull(GraphQLString),
+      // FIXME: Change to required field after LINE bot is implemented
+      // type: new GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
       description:
         'The reason why the user want to submit this article. Mandatory for 1st sender',
     },

--- a/src/graphql/mutations/CreateOrUpdateArticleReplyFeedback.js
+++ b/src/graphql/mutations/CreateOrUpdateArticleReplyFeedback.js
@@ -3,10 +3,10 @@ import {
   GraphQLNonNull,
   GraphQLInt,
   GraphQLObjectType,
-  GraphQLEnumType,
 } from 'graphql';
 
 import { assertUser } from 'graphql/util';
+import FeedbackVote from 'graphql/models/FeedbackVote';
 
 import client from 'util/client';
 
@@ -32,18 +32,7 @@ export default {
   args: {
     articleId: { type: new GraphQLNonNull(GraphQLString) },
     replyId: { type: new GraphQLNonNull(GraphQLString) },
-    vote: {
-      type: new GraphQLNonNull(
-        new GraphQLEnumType({
-          name: 'FeedbackVote',
-          values: {
-            UPVOTE: { value: 1 },
-            NEUTRAL: { value: 0 },
-            DOWNVOTE: { value: -1 },
-          },
-        })
-      ),
-    },
+    vote: { type: new GraphQLNonNull(FeedbackVote) },
   },
   async resolve(
     rootValue,

--- a/src/graphql/mutations/CreateOrUpdateReplyRequestFeedback.js
+++ b/src/graphql/mutations/CreateOrUpdateReplyRequestFeedback.js
@@ -1,0 +1,95 @@
+import {
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLInt,
+  GraphQLObjectType,
+} from 'graphql';
+
+import { assertUser } from 'graphql/util';
+import FeedbackVote from 'graphql/models/FeedbackVote';
+
+import client from 'util/client';
+
+export default {
+  description: 'Create or update a feedback on a reply request reason',
+  type: new GraphQLObjectType({
+    name: 'CreateOrUpdateReplyRequestFeedbackResult',
+    fields: {
+      feedbackCount: { type: GraphQLInt },
+      positiveFeedbackCount: { type: GraphQLInt },
+      negativeFeedbackCount: { type: GraphQLInt },
+    },
+  }),
+  args: {
+    replyRequestId: { type: new GraphQLNonNull(GraphQLString) },
+    vote: { type: new GraphQLNonNull(FeedbackVote) },
+  },
+  async resolve(rootValue, { replyRequestId, vote }, { appId, userId }) {
+    assertUser({ appId, userId });
+
+    const now = new Date().toISOString();
+
+    const {
+      get: {
+        _source: { positiveFeedbackCount, negativeFeedbackCount, feedbacks },
+      },
+    } = await client.update({
+      index: 'replyrequests',
+      type: 'doc',
+      id: replyRequestId,
+      body: {
+        script: {
+          source: `
+            int idx = 0;
+            int feedbackCount = ctx._source.feedbacks.size();
+            for(; idx < feedbackCount; idx += 1) {
+              HashMap feedback = ctx._source.feedbacks.get(idx);
+              if(
+                feedback.get('userId').equals(params.userId) &&
+                feedback.get('appId').equals(params.appId)
+              ) {
+                break;
+              }
+            }
+
+            if( idx === feedbackCount ) {
+              HashMap newFeedback = new HashMap();
+
+              newFeedback.put('userId', params.userId);
+              newFeedback.put('appId', params.appId);
+              newFeedback.put('score', params.score);
+              newFeedback.put('createdAt', params.now);
+              newFeedback.put('updatedAt', params.now);
+
+              ctx._source.feedbacks.add(newFeedback);
+            } else {
+              ctx._source.feedbacks.get(idx).put('score', params.score);
+              ctx._source.feedbacks.get(idx).put('updatedAt', params.now);
+            }
+
+            ctx._source.positiveFeedbackCount = ctx._source.feedbacks.stream().filter(
+              ar -> ar.get('score').equals(1)
+            ).count();
+            ctx._source.negativeFeedbackCount = ctx._source.feedbacks.stream().filter(
+              ar -> ar.get('score').equals(-1)
+            ).count();
+          `,
+          params: {
+            userId,
+            appId,
+            score: vote,
+            now,
+          },
+          lang: 'painless',
+        },
+      },
+      _source: true,
+    });
+
+    return {
+      feedbackCount: feedbacks.length,
+      negativeFeedbackCount,
+      positiveFeedbackCount,
+    };
+  },
+};

--- a/src/graphql/mutations/CreateReplyRequest.js
+++ b/src/graphql/mutations/CreateReplyRequest.js
@@ -11,9 +11,10 @@ import client, { processMeta } from 'util/client';
 
 /**
  * @typedef {Object} ReplyRequestParam
- * @property {string} opt.articleId - The article to add reply request to
- * @property {string} opt.userId - The user that submits this request
- * @property {string} opt.appId - The app that the user logged in to
+ * @property {string} articleId - The article to add reply request to
+ * @property {string} userId - The user that submits this request
+ * @property {string} appId - The app that the user logged in to
+ * @property {string} reason - The reason why the user want to submit this article
  */
 
 /**
@@ -36,7 +37,12 @@ export function getReplyRequestId({ articleId, userId, appId }) {
  * @param {ReplyRequestParam} param
  * @returns {CreateReplyRequstResult}
  */
-export async function createReplyRequest({ articleId, userId, appId }) {
+export async function createReplyRequest({
+  articleId,
+  userId,
+  appId,
+  reason = '',
+}) {
   assertUser({ appId, userId });
 
   const now = new Date().toISOString();
@@ -54,6 +60,10 @@ export async function createReplyRequest({ articleId, userId, appId }) {
         articleId,
         userId,
         appId,
+        reason,
+        feedbacks: [],
+        positiveFeedbackCount: 0,
+        negativeFeedbackCount: 0,
         createdAt: now,
         updatedAt: now,
       },
@@ -118,12 +128,17 @@ export default {
   }),
   args: {
     articleId: { type: new GraphQLNonNull(GraphQLString) },
+    reason: {
+      type: GraphQLString,
+      description: 'The reason why the user want to submit this article',
+    },
   },
-  async resolve(rootValue, { articleId }, { appId, userId }) {
+  async resolve(rootValue, { articleId, reason }, { appId, userId }) {
     const { article, isCreated } = await createReplyRequest({
       articleId,
       appId,
       userId,
+      reason,
     });
     return {
       replyRequestCount: article.replyRequestCount,

--- a/src/graphql/mutations/__fixtures__/CreateOrUpdateReplyRequestFeedback.js
+++ b/src/graphql/mutations/__fixtures__/CreateOrUpdateReplyRequestFeedback.js
@@ -1,0 +1,21 @@
+export default {
+  '/replyrequests/doc/foo': {
+    articleId: 'foo-article',
+    userId: 'user',
+    appId: 'app',
+    reason: 'foo-reason',
+    feedbacks: [
+      {
+        userId: 'fb-user-1',
+        appId: 'app',
+        score: 1,
+        createdAt: '2017-01-01T00:00:00.000Z',
+        updatedAt: '2017-01-01T00:00:00.000Z',
+      },
+    ],
+    positiveFeedbackCount: 1,
+    negativeFeedbackCount: 0,
+    createdAt: '2017-01-01T00:00:00.000Z',
+    updatedAt: '2017-01-01T00:00:00.000Z',
+  },
+};

--- a/src/graphql/mutations/__tests__/CreateArticle.js
+++ b/src/graphql/mutations/__tests__/CreateArticle.js
@@ -13,7 +13,11 @@ it('creates articles and a reply request', async () => {
 
   const { data, errors } = await gql`
     mutation($text: String!, $reference: ArticleReferenceInput!) {
-      CreateArticle(text: $text, reference: $reference) {
+      CreateArticle(
+        text: $text
+        reference: $reference
+        reason: "気になります"
+      ) {
         id
       }
     }
@@ -75,7 +79,11 @@ it('avoids creating duplicated articles and adds replyRequests automatically', a
 
   const { data, errors } = await gql`
     mutation($text: String!, $reference: ArticleReferenceInput!) {
-      CreateArticle(text: $text, reference: $reference) {
+      CreateArticle(
+        text: $text
+        reference: $reference
+        reason: "気になります"
+      ) {
         id
       }
     }

--- a/src/graphql/mutations/__tests__/CreateOrUpdateReplyRequestFeedback.js
+++ b/src/graphql/mutations/__tests__/CreateOrUpdateReplyRequestFeedback.js
@@ -1,0 +1,89 @@
+import gql from 'util/GraphQL';
+import { loadFixtures, unloadFixtures, resetFrom } from 'util/fixtures';
+import client from 'util/client';
+import MockDate from 'mockdate';
+import fixtures from '../__fixtures__/CreateOrUpdateReplyRequestFeedback';
+
+describe('CreateOrUpdateReplyRequestFeedback', () => {
+  beforeAll(() => loadFixtures(fixtures));
+
+  it('creates new feedback', async () => {
+    MockDate.set(1485593157011);
+    const userId = 'fb-user-2';
+    const appId = 'app';
+    const replyRequestId = 'foo';
+
+    const { data, errors } = await gql`
+      mutation($replyRequestId: String!) {
+        CreateOrUpdateReplyRequestFeedback(
+          replyRequestId: $replyRequestId
+          vote: UPVOTE
+        ) {
+          feedbackCount
+          positiveFeedbackCount
+          negativeFeedbackCount
+        }
+      }
+    `(
+      {
+        replyRequestId,
+      },
+      { userId, appId }
+    );
+    MockDate.reset();
+
+    expect(errors).toBeUndefined();
+    expect(data).toMatchSnapshot();
+
+    const replyrequest = await client.get({
+      index: 'replyrequests',
+      type: 'doc',
+      id: replyRequestId,
+    });
+    expect(replyrequest._source).toMatchSnapshot();
+
+    // Cleanup
+    await resetFrom(fixtures, '/replyrequests/doc/foo');
+  });
+
+  it('updates existing feedback', async () => {
+    MockDate.set(1485593157011);
+    const userId = 'fb-user-1';
+    const appId = 'app';
+    const replyRequestId = 'foo';
+
+    const { data, errors } = await gql`
+      mutation($replyRequestId: String!) {
+        CreateOrUpdateReplyRequestFeedback(
+          replyRequestId: $replyRequestId
+          vote: DOWNVOTE
+        ) {
+          feedbackCount
+          positiveFeedbackCount
+          negativeFeedbackCount
+        }
+      }
+    `(
+      {
+        replyRequestId,
+      },
+      { userId, appId }
+    );
+    MockDate.reset();
+
+    expect(errors).toBeUndefined();
+    expect(data).toMatchSnapshot();
+
+    const replyrequest = await client.get({
+      index: 'replyrequests',
+      type: 'doc',
+      id: replyRequestId,
+    });
+    expect(replyrequest._source).toMatchSnapshot();
+
+    // Cleanup
+    await resetFrom(fixtures, '/replyrequests/doc/foo');
+  });
+
+  afterAll(() => unloadFixtures(fixtures));
+});

--- a/src/graphql/mutations/__tests__/CreateReplyRequest.js
+++ b/src/graphql/mutations/__tests__/CreateReplyRequest.js
@@ -16,7 +16,7 @@ describe('CreateReplyRequest', () => {
 
     const { data, errors } = await gql`
       mutation($articleId: String!) {
-        CreateReplyRequest(articleId: $articleId) {
+        CreateReplyRequest(articleId: $articleId, reason: "気になります") {
           replyRequestCount
           status
         }

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateArticle.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateArticle.js.snap
@@ -25,6 +25,10 @@ Object {
   "appId": "foo",
   "articleId": "20xz7y20qzyt6",
   "createdAt": "2017-01-28T08:45:57.011Z",
+  "feedbacks": Array [],
+  "negativeFeedbackCount": 0,
+  "positiveFeedbackCount": 0,
+  "reason": "気になります",
   "updatedAt": "2017-01-28T08:45:57.011Z",
   "userId": "test",
 }
@@ -58,6 +62,10 @@ Object {
   "appId": "foo",
   "articleId": "mdw91a2ngnnt",
   "createdAt": "2017-01-28T08:45:57.011Z",
+  "feedbacks": Array [],
+  "negativeFeedbackCount": 0,
+  "positiveFeedbackCount": 0,
+  "reason": "気になります",
   "updatedAt": "2017-01-28T08:45:57.011Z",
   "userId": "test",
 }

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateOrUpdateReplyRequestFeedback.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateOrUpdateReplyRequestFeedback.js.snap
@@ -1,0 +1,72 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CreateOrUpdateReplyRequestFeedback creates new feedback 1`] = `
+Object {
+  "CreateOrUpdateReplyRequestFeedback": Object {
+    "feedbackCount": 2,
+    "negativeFeedbackCount": 0,
+    "positiveFeedbackCount": 2,
+  },
+}
+`;
+
+exports[`CreateOrUpdateReplyRequestFeedback creates new feedback 2`] = `
+Object {
+  "appId": "app",
+  "articleId": "foo-article",
+  "createdAt": "2017-01-01T00:00:00.000Z",
+  "feedbacks": Array [
+    Object {
+      "appId": "app",
+      "createdAt": "2017-01-01T00:00:00.000Z",
+      "score": 1,
+      "updatedAt": "2017-01-01T00:00:00.000Z",
+      "userId": "fb-user-1",
+    },
+    Object {
+      "appId": "app",
+      "createdAt": "2017-01-28T08:45:57.011Z",
+      "score": 1,
+      "updatedAt": "2017-01-28T08:45:57.011Z",
+      "userId": "fb-user-2",
+    },
+  ],
+  "negativeFeedbackCount": 0,
+  "positiveFeedbackCount": 2,
+  "reason": "foo-reason",
+  "updatedAt": "2017-01-01T00:00:00.000Z",
+  "userId": "user",
+}
+`;
+
+exports[`CreateOrUpdateReplyRequestFeedback updates existing feedback 1`] = `
+Object {
+  "CreateOrUpdateReplyRequestFeedback": Object {
+    "feedbackCount": 1,
+    "negativeFeedbackCount": 1,
+    "positiveFeedbackCount": 0,
+  },
+}
+`;
+
+exports[`CreateOrUpdateReplyRequestFeedback updates existing feedback 2`] = `
+Object {
+  "appId": "app",
+  "articleId": "foo-article",
+  "createdAt": "2017-01-01T00:00:00.000Z",
+  "feedbacks": Array [
+    Object {
+      "appId": "app",
+      "createdAt": "2017-01-01T00:00:00.000Z",
+      "score": -1,
+      "updatedAt": "2017-01-28T08:45:57.011Z",
+      "userId": "fb-user-1",
+    },
+  ],
+  "negativeFeedbackCount": 1,
+  "positiveFeedbackCount": 0,
+  "reason": "foo-reason",
+  "updatedAt": "2017-01-01T00:00:00.000Z",
+  "userId": "user",
+}
+`;

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateReplyRequest.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateReplyRequest.js.snap
@@ -14,6 +14,10 @@ Object {
   "appId": "test",
   "articleId": "createReplyRequestTest1",
   "createdAt": "2017-01-28T08:45:57.011Z",
+  "feedbacks": Array [],
+  "negativeFeedbackCount": 0,
+  "positiveFeedbackCount": 0,
+  "reason": "気になります",
   "updatedAt": "2017-01-28T08:45:57.011Z",
   "userId": "test",
 }
@@ -41,6 +45,10 @@ Object {
   "appId": "test",
   "articleId": "createReplyRequestTest1",
   "createdAt": "2017-01-28T08:45:57.011Z",
+  "feedbacks": Array [],
+  "negativeFeedbackCount": 0,
+  "positiveFeedbackCount": 0,
+  "reason": "",
   "updatedAt": "2017-01-28T08:47:37.011Z",
   "userId": "test",
 }

--- a/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
+++ b/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
@@ -69,13 +69,15 @@ export default {
     articleId: 'foo',
     userId: 'fakeUser',
     appId: 'LINE',
+    reason: 'Reason foo',
+    feedbacks: [{ score: 1 }, { score: -1 }],
   },
-  [`/articlereplyfeedbacks/doc/${getArticleReplyFeedbackId(
-    'foo',
-    'bar',
-    'test-user',
-    'test-app'
-  )}`]: {
+  [`/articlereplyfeedbacks/doc/${getArticleReplyFeedbackId({
+    articleId: 'foo',
+    replyId: 'bar',
+    userId: 'test-user',
+    appId: 'test-app',
+  })}`]: {
     articleId: 'foo',
     replyId: 'bar',
     userId: 'test-user',

--- a/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
+++ b/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
@@ -72,7 +72,8 @@ export default {
     reason: 'Reason foo',
     feedbacks: [{ score: 1 }, { score: -1 }],
   },
-  '/replyrequests/doc/articleTest2': { // Legacy reply request that has no feedbacks[] nor reason.
+  '/replyrequests/doc/articleTest2': {
+    // Legacy reply request that has no feedbacks[] nor reason.
     articleId: 'foo',
     userId: 'fakeUser',
     appId: 'LINE',

--- a/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
+++ b/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
@@ -72,6 +72,11 @@ export default {
     reason: 'Reason foo',
     feedbacks: [{ score: 1 }, { score: -1 }],
   },
+  '/replyrequests/doc/articleTest2': { // Legacy reply request that has no feedbacks[] nor reason.
+    articleId: 'foo',
+    userId: 'fakeUser',
+    appId: 'LINE',
+  },
   [`/articlereplyfeedbacks/doc/${getArticleReplyFeedbackId({
     articleId: 'foo',
     replyId: 'bar',

--- a/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
+++ b/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
@@ -34,6 +34,12 @@ describe('GetReplyAndGetArticle', () => {
                 }
               }
               replyRequestCount
+              replyRequests {
+                reason
+                feedbackCount
+                positiveFeedbackCount
+                negativeFeedbackCount
+              }
               requestedForReply
             }
           }

--- a/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
@@ -194,6 +194,12 @@ Object {
           "positiveFeedbackCount": 1,
           "reason": "Reason foo",
         },
+        Object {
+          "feedbackCount": 0,
+          "negativeFeedbackCount": 0,
+          "positiveFeedbackCount": 0,
+          "reason": null,
+        },
       ],
       "requestedForReply": true,
       "text": "Lorum ipsum",

--- a/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
@@ -187,7 +187,15 @@ Object {
       ],
       "replyCount": 1,
       "replyRequestCount": 1,
-      "requestedForReply": false,
+      "replyRequests": Array [
+        Object {
+          "feedbackCount": 2,
+          "negativeFeedbackCount": 1,
+          "positiveFeedbackCount": 1,
+          "reason": "Reason foo",
+        },
+      ],
+      "requestedForReply": true,
       "text": "Lorum ipsum",
     },
   },

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -12,6 +12,7 @@ import CreateArticle from './mutations/CreateArticle';
 import CreateReply from './mutations/CreateReply';
 import CreateArticleReply from './mutations/CreateArticleReply';
 import CreateOrUpdateArticleReplyFeedback from './mutations/CreateOrUpdateArticleReplyFeedback';
+import CreateOrUpdateReplyRequestFeedback from './mutations/CreateOrUpdateReplyRequestFeedback';
 import CreateReplyRequest from './mutations/CreateReplyRequest';
 import UpdateArticleReplyStatus from './mutations/UpdateArticleReplyStatus';
 import UpdateUser from './mutations/UpdateUser';
@@ -35,6 +36,7 @@ export default new GraphQLSchema({
       CreateArticleReply,
       CreateReplyRequest,
       CreateOrUpdateArticleReplyFeedback,
+      CreateOrUpdateReplyRequestFeedback,
       UpdateArticleReplyStatus,
       UpdateUser,
     },


### PR DESCRIPTION
This PR:

- adds required arg `reason` to `CreateArticle`
- adds optional arg `reason` to `CreateReplyRequest`
- adds `reason` field to `ReplyRequest` object type
- adds `CreateOrUpdateReplyRequestFeedback`, which allows editors to vote on the usefulness of reply request reasons

Related DB schema change: https://github.com/cofacts/rumors-db/pull/13
Fixes #67 

## BREAKING CHANGE

rumors-line-bot should provide `reason` when submitting articles, or submissions will fail.