### PR TITLE
#92: deprecated api

### DIFF
--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -135,7 +135,7 @@ const Article = new GraphQLObjectType({
               filter: {
                 script: {
                   script: {
-                    inline: `doc['normalArticleReplyCount'].value ${operator} params.operand`,
+                    source: `doc['normalArticleReplyCount'].value ${operator} params.operand`,
                     params: {
                       operand,
                     },

--- a/src/graphql/mutations/__tests__/CreateArticle.js
+++ b/src/graphql/mutations/__tests__/CreateArticle.js
@@ -129,3 +129,29 @@ it('avoids creating duplicated articles and adds replyRequests automatically', a
 
   await unloadFixtures(fixtures);
 });
+
+const testId = async (userId, appId) => {
+  MockDate.set(1485593157011);
+  const { errors } = await gql`
+    mutation($text: String!, $reference: ArticleReferenceInput!) {
+      CreateArticle(
+        text: $text
+        reference: $reference
+        reason: "気になります"
+      ) {
+        id
+      }
+    }
+  `(
+    {
+      text: 'FOO FOO',
+      reference: { type: 'LINE' },
+    },
+    { userId, appId }
+  );
+  MockDate.reset();
+  expect(errors).toMatchSnapshot();
+};
+
+it('fails with an invalid user id', () => testId('', ''));
+it('fails with an invalid app id', () => testId('test', ''));

--- a/src/graphql/mutations/__tests__/CreateReply.js
+++ b/src/graphql/mutations/__tests__/CreateReply.js
@@ -36,6 +36,7 @@ describe('CreateReply', () => {
       },
       { userId: 'test', appId: 'test' }
     );
+    MockDate.reset();
 
     expect(errors).toBeUndefined();
 
@@ -54,7 +55,6 @@ describe('CreateReply', () => {
     });
     expect(article._source.articleReplies[0].replyId).toBe(replyId);
 
-    MockDate.reset();
     // Cleanup
     await client.delete({ index: 'replies', type: 'doc', id: replyId });
     await resetFrom(fixtures, `/articles/doc/${articleId}`);

--- a/src/graphql/mutations/__tests__/CreateReply.js
+++ b/src/graphql/mutations/__tests__/CreateReply.js
@@ -36,7 +36,6 @@ describe('CreateReply', () => {
       },
       { userId: 'test', appId: 'test' }
     );
-    MockDate.reset();
 
     expect(errors).toBeUndefined();
 
@@ -55,8 +54,35 @@ describe('CreateReply', () => {
     });
     expect(article._source.articleReplies[0].replyId).toBe(replyId);
 
+    MockDate.reset();
     // Cleanup
     await client.delete({ index: 'replies', type: 'doc', id: replyId });
+    await resetFrom(fixtures, `/articles/doc/${articleId}`);
+  });
+
+  it('should throw error since a reference is required for type !== NOT_ARTICLE', async () => {
+    MockDate.set(1485593157011);
+    const articleId = 'setReplyTest1';
+
+    const { errors } = await gql`
+      mutation($articleId: String!, $text: String!, $type: ReplyTypeEnum!) {
+        CreateReply(articleId: $articleId, text: $text, type: $type) {
+          id
+        }
+      }
+    `(
+      {
+        articleId,
+        text: 'FOO FOO',
+        type: 'RUMOR',
+      },
+      { userId: 'test', appId: 'test' }
+    );
+    MockDate.reset();
+
+    expect(errors).toMatchSnapshot();
+
+    // Cleanup
     await resetFrom(fixtures, `/articles/doc/${articleId}`);
   });
 

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateArticle.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateArticle.js.snap
@@ -70,3 +70,15 @@ Object {
   "userId": "test",
 }
 `;
+
+exports[`fails with an invalid app id 1`] = `
+Array [
+  [GraphQLError: userId is set, but x-app-id or x-app-secret is not set accordingly.],
+]
+`;
+
+exports[`fails with an invalid user id 1`] = `
+Array [
+  [GraphQLError: userId is not set via query string.],
+]
+`;

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateReply.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateReply.js.snap
@@ -10,3 +10,9 @@ Object {
   "userId": "test",
 }
 `;
+
+exports[`CreateReply should throw error since a reference is required for type !== NOT_ARTICLE 1`] = `
+Array [
+  [GraphQLError: reference is required for type !== NOT_ARTICLE],
+]
+`;

--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -143,7 +143,7 @@ export default {
       filterQueries.push({
         script: {
           script: {
-            inline: `doc['normalArticleReplyCount'].value ${operator} params.operand`,
+            source: `doc['normalArticleReplyCount'].value ${operator} params.operand`,
             params: {
               operand,
             },
@@ -159,7 +159,7 @@ export default {
       filterQueries.push({
         script: {
           script: {
-            inline: `doc['replyRequestCount'].value ${operator} params.operand`,
+            source: `doc['replyRequestCount'].value ${operator} params.operand`,
             params: {
               operand,
             },

--- a/src/graphql/queries/__tests__/ListArticles.js
+++ b/src/graphql/queries/__tests__/ListArticles.js
@@ -218,7 +218,7 @@ describe('ListArticles', () => {
             }
           }
         }
-      `({ cursor: getCursor(['doc#listArticleTest2']) })
+      `({ cursor: getCursor(['listArticleTest2']) })
     ).toMatchSnapshot();
   });
 
@@ -239,7 +239,7 @@ describe('ListArticles', () => {
             }
           }
         }
-      `({ cursor: getCursor(['doc#listArticleTest2']) })
+      `({ cursor: getCursor(['listArticleTest2']) })
     ).toMatchSnapshot();
   });
 

--- a/src/graphql/queries/__tests__/ListArticles.js
+++ b/src/graphql/queries/__tests__/ListArticles.js
@@ -68,12 +68,13 @@ describe('ListArticles', () => {
     ).toMatchSnapshot();
   });
 
-  it('filters by replyCount', async () => {
+  const testReplyCount = async expression => {
     // Lists only articles with more than one reply.
+    const pair = expression ? `${expression}: 1` : expression;
     expect(
       await gql`
         {
-          ListArticles(filter: { replyCount: { GT: 1 } }) {
+          ListArticles(filter: { replyCount: {${pair}} }) {
             edges {
               node {
                 id
@@ -88,7 +89,13 @@ describe('ListArticles', () => {
         }
       `()
     ).toMatchSnapshot();
-  });
+  };
+
+  it('filters by replyCount EQ', () => testReplyCount('EQ'));
+  it('filters by replyCount LT', () => testReplyCount('LT'));
+  it('filters by replyCount GT', () => testReplyCount('GT'));
+  it('filters by invalid operator', () => testReplyCount('INVALID'));
+  it('filters by null operator', () => testReplyCount(''));
 
   it('filters by moreLikeThis', async () => {
     // moreLikeThis query
@@ -227,6 +234,27 @@ describe('ListArticles', () => {
       await gql`
         query($cursor: String) {
           ListArticles(before: $cursor) {
+            edges {
+              node {
+                id
+              }
+            }
+            totalCount
+            pageInfo {
+              firstCursor
+              lastCursor
+            }
+          }
+        }
+      `({ cursor: getCursor(['listArticleTest2']) })
+    ).toMatchSnapshot();
+  });
+
+  it('should fail if before and after both exist', async () => {
+    expect(
+      await gql`
+        query($cursor: String) {
+          ListArticles(before: $cursor, after: $cursor) {
             edges {
               node {
                 id

--- a/src/graphql/queries/__tests__/ListReplies.js
+++ b/src/graphql/queries/__tests__/ListReplies.js
@@ -133,7 +133,7 @@ describe('ListReplies', () => {
             }
           }
         }
-      `({ cursor: getCursor(['doc#moreLikeThis2']) })
+      `({ cursor: getCursor(['moreLikeThis2']) })
     ).toMatchSnapshot();
   });
 
@@ -154,7 +154,7 @@ describe('ListReplies', () => {
             }
           }
         }
-      `({ cursor: getCursor(['doc#moreLikeThis1']) })
+      `({ cursor: getCursor(['moreLikeThis1']) })
     ).toMatchSnapshot();
   });
 

--- a/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
@@ -34,7 +34,7 @@ Object {
       "relatedArticles": Object {
         "edges": Array [
           Object {
-            "cursor": "WyJkb2MjZm9vMyJd",
+            "cursor": "WyJmb28zIl0=",
             "node": Object {
               "id": "foo3",
               "text": "Lorum ipsum Lorum ipsum Lorum ipsum",
@@ -42,7 +42,7 @@ Object {
             "score": 0.37905684,
           },
           Object {
-            "cursor": "WyJkb2MjZm9vMiJd",
+            "cursor": "WyJmb28yIl0=",
             "node": Object {
               "id": "foo2",
               "text": "Lorum ipsum Lorum ipsum",
@@ -63,7 +63,7 @@ Object {
       "relatedArticles": Object {
         "edges": Array [
           Object {
-            "cursor": "WyJkb2MjZm9vMyJd",
+            "cursor": "WyJmb28zIl0=",
             "node": Object {
               "id": "foo3",
               "text": "Lorum ipsum Lorum ipsum Lorum ipsum",
@@ -71,7 +71,7 @@ Object {
             "score": 0.37905684,
           },
           Object {
-            "cursor": "WyJkb2MjZm9vMiJd",
+            "cursor": "WyJmb28yIl0=",
             "node": Object {
               "id": "foo2",
               "text": "Lorum ipsum Lorum ipsum",
@@ -92,7 +92,7 @@ Object {
       "relatedArticles": Object {
         "edges": Array [
           Object {
-            "cursor": "WzAuMzY3MjExMywiZG9jI2ZvbzIiXQ==",
+            "cursor": "WzAuMzY3MjExMywiZm9vMiJd",
             "node": Object {
               "id": "foo2",
               "text": "Lorum ipsum Lorum ipsum",
@@ -100,7 +100,7 @@ Object {
             "score": 0.3672113,
           },
           Object {
-            "cursor": "WzAuMzc5MDU2ODQsImRvYyNmb28zIl0=",
+            "cursor": "WzAuMzc5MDU2ODQsImZvbzMiXQ==",
             "node": Object {
               "id": "foo3",
               "text": "Lorum ipsum Lorum ipsum Lorum ipsum",

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
@@ -32,8 +32,8 @@ Object {
         },
       ],
       "pageInfo": Object {
-        "firstCursor": "WyJkb2MjbGlzdEFydGljbGVUZXN0MyJd",
-        "lastCursor": "WyJkb2MjbGlzdEFydGljbGVUZXN0MSJd",
+        "firstCursor": "WyJsaXN0QXJ0aWNsZVRlc3QzIl0=",
+        "lastCursor": "WyJsaXN0QXJ0aWNsZVRlc3QxIl0=",
       },
       "totalCount": 2,
     },
@@ -53,8 +53,8 @@ Object {
         },
       ],
       "pageInfo": Object {
-        "firstCursor": "WyJkb2MjbGlzdEFydGljbGVUZXN0MSJd",
-        "lastCursor": "WyJkb2MjbGlzdEFydGljbGVUZXN0MSJd",
+        "firstCursor": "WyJsaXN0QXJ0aWNsZVRlc3QxIl0=",
+        "lastCursor": "WyJsaXN0QXJ0aWNsZVRlc3QxIl0=",
       },
       "totalCount": 1,
     },
@@ -129,27 +129,27 @@ Object {
     "ListArticles": Object {
       "edges": Array [
         Object {
-          "cursor": "WyJkb2MjbGlzdEFydGljbGVUZXN0MyJd",
+          "cursor": "WyJsaXN0QXJ0aWNsZVRlc3QzIl0=",
           "node": Object {
             "id": "listArticleTest3",
           },
         },
         Object {
-          "cursor": "WyJkb2MjbGlzdEFydGljbGVUZXN0MiJd",
+          "cursor": "WyJsaXN0QXJ0aWNsZVRlc3QyIl0=",
           "node": Object {
             "id": "listArticleTest2",
           },
         },
         Object {
-          "cursor": "WyJkb2MjbGlzdEFydGljbGVUZXN0MSJd",
+          "cursor": "WyJsaXN0QXJ0aWNsZVRlc3QxIl0=",
           "node": Object {
             "id": "listArticleTest1",
           },
         },
       ],
       "pageInfo": Object {
-        "firstCursor": "WyJkb2MjbGlzdEFydGljbGVUZXN0MyJd",
-        "lastCursor": "WyJkb2MjbGlzdEFydGljbGVUZXN0MSJd",
+        "firstCursor": "WyJsaXN0QXJ0aWNsZVRlc3QzIl0=",
+        "lastCursor": "WyJsaXN0QXJ0aWNsZVRlc3QxIl0=",
       },
       "totalCount": 3,
     },
@@ -179,8 +179,8 @@ Object {
         },
       ],
       "pageInfo": Object {
-        "firstCursor": "WzMsImRvYyNsaXN0QXJ0aWNsZVRlc3QzIl0=",
-        "lastCursor": "WzEsImRvYyNsaXN0QXJ0aWNsZVRlc3QxIl0=",
+        "firstCursor": "WzMsImxpc3RBcnRpY2xlVGVzdDMiXQ==",
+        "lastCursor": "WzEsImxpc3RBcnRpY2xlVGVzdDEiXQ==",
       },
       "totalCount": 3,
     },
@@ -210,8 +210,8 @@ Object {
         },
       ],
       "pageInfo": Object {
-        "firstCursor": "WzIsImRvYyNsaXN0QXJ0aWNsZVRlc3QxIl0=",
-        "lastCursor": "WzAsImRvYyNsaXN0QXJ0aWNsZVRlc3QzIl0=",
+        "firstCursor": "WzIsImxpc3RBcnRpY2xlVGVzdDEiXQ==",
+        "lastCursor": "WzAsImxpc3RBcnRpY2xlVGVzdDMiXQ==",
       },
       "totalCount": 3,
     },
@@ -231,8 +231,8 @@ Object {
         },
       ],
       "pageInfo": Object {
-        "firstCursor": "WyJkb2MjbGlzdEFydGljbGVUZXN0MyJd",
-        "lastCursor": "WyJkb2MjbGlzdEFydGljbGVUZXN0MSJd",
+        "firstCursor": "WyJsaXN0QXJ0aWNsZVRlc3QzIl0=",
+        "lastCursor": "WyJsaXN0QXJ0aWNsZVRlc3QxIl0=",
       },
       "totalCount": 3,
     },
@@ -252,8 +252,8 @@ Object {
         },
       ],
       "pageInfo": Object {
-        "firstCursor": "WyJkb2MjbGlzdEFydGljbGVUZXN0MyJd",
-        "lastCursor": "WyJkb2MjbGlzdEFydGljbGVUZXN0MSJd",
+        "firstCursor": "WyJsaXN0QXJ0aWNsZVRlc3QzIl0=",
+        "lastCursor": "WyJsaXN0QXJ0aWNsZVRlc3QxIl0=",
       },
       "totalCount": 3,
     },

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
@@ -15,6 +15,14 @@ Object {
 }
 `;
 
+exports[`ListArticles filters by invalid operator 1`] = `
+Object {
+  "errors": Array [
+    [GraphQLError: Field "INVALID" is not defined by type ListArticleReplyCountExpr.],
+  ],
+}
+`;
+
 exports[`ListArticles filters by moreLikeThis 1`] = `
 Object {
   "data": Object {
@@ -41,7 +49,39 @@ Object {
 }
 `;
 
-exports[`ListArticles filters by replyCount 1`] = `
+exports[`ListArticles filters by null operator 1`] = `
+Object {
+  "data": Object {
+    "ListArticles": null,
+  },
+  "errors": Array [
+    [GraphQLError: Invalid Expression!],
+  ],
+}
+`;
+
+exports[`ListArticles filters by replyCount EQ 1`] = `
+Object {
+  "data": Object {
+    "ListArticles": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "listArticleTest2",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "firstCursor": "WyJsaXN0QXJ0aWNsZVRlc3QyIl0=",
+        "lastCursor": "WyJsaXN0QXJ0aWNsZVRlc3QyIl0=",
+      },
+      "totalCount": 1,
+    },
+  },
+}
+`;
+
+exports[`ListArticles filters by replyCount GT 1`] = `
 Object {
   "data": Object {
     "ListArticles": Object {
@@ -55,6 +95,27 @@ Object {
       "pageInfo": Object {
         "firstCursor": "WyJsaXN0QXJ0aWNsZVRlc3QxIl0=",
         "lastCursor": "WyJsaXN0QXJ0aWNsZVRlc3QxIl0=",
+      },
+      "totalCount": 1,
+    },
+  },
+}
+`;
+
+exports[`ListArticles filters by replyCount LT 1`] = `
+Object {
+  "data": Object {
+    "ListArticles": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "listArticleTest3",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "firstCursor": "WyJsaXN0QXJ0aWNsZVRlc3QzIl0=",
+        "lastCursor": "WyJsaXN0QXJ0aWNsZVRlc3QzIl0=",
       },
       "totalCount": 1,
     },
@@ -154,6 +215,24 @@ Object {
       "totalCount": 3,
     },
   },
+}
+`;
+
+exports[`ListArticles should fail if before and after both exist 1`] = `
+Object {
+  "data": Object {
+    "ListArticles": Object {
+      "edges": null,
+      "pageInfo": Object {
+        "firstCursor": "WyJsaXN0QXJ0aWNsZVRlc3QzIl0=",
+        "lastCursor": "WyJsaXN0QXJ0aWNsZVRlc3QxIl0=",
+      },
+      "totalCount": 3,
+    },
+  },
+  "errors": Array [
+    [GraphQLError: Use of before & after is prohibited.],
+  ],
 }
 `;
 

--- a/src/graphql/queries/__tests__/__snapshots__/ListReplies.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListReplies.js.snap
@@ -17,8 +17,8 @@ Object {
         },
       ],
       "pageInfo": Object {
-        "firstCursor": "WyJkb2MjbW9yZUxpa2VUaGlzMiJd",
-        "lastCursor": "WyJkb2MjbW9yZUxpa2VUaGlzMSJd",
+        "firstCursor": "WyJtb3JlTGlrZVRoaXMyIl0=",
+        "lastCursor": "WyJtb3JlTGlrZVRoaXMxIl0=",
       },
       "totalCount": 2,
     },
@@ -38,8 +38,8 @@ Object {
         },
       ],
       "pageInfo": Object {
-        "firstCursor": "WyJkb2MjdXNlckZvbyJd",
-        "lastCursor": "WyJkb2MjdXNlckZvbyJd",
+        "firstCursor": "WyJ1c2VyRm9vIl0=",
+        "lastCursor": "WyJ1c2VyRm9vIl0=",
       },
       "totalCount": 1,
     },
@@ -59,8 +59,8 @@ Object {
         },
       ],
       "pageInfo": Object {
-        "firstCursor": "WyJkb2MjcnVtb3IiXQ==",
-        "lastCursor": "WyJkb2MjcnVtb3IiXQ==",
+        "firstCursor": "WyJydW1vciJd",
+        "lastCursor": "WyJydW1vciJd",
       },
       "totalCount": 1,
     },
@@ -85,33 +85,33 @@ Object {
     "ListReplies": Object {
       "edges": Array [
         Object {
-          "cursor": "WyJkb2MjdXNlckZvbyJd",
+          "cursor": "WyJ1c2VyRm9vIl0=",
           "node": Object {
             "id": "userFoo",
           },
         },
         Object {
-          "cursor": "WyJkb2MjcnVtb3IiXQ==",
+          "cursor": "WyJydW1vciJd",
           "node": Object {
             "id": "rumor",
           },
         },
         Object {
-          "cursor": "WyJkb2MjbW9yZUxpa2VUaGlzMiJd",
+          "cursor": "WyJtb3JlTGlrZVRoaXMyIl0=",
           "node": Object {
             "id": "moreLikeThis2",
           },
         },
         Object {
-          "cursor": "WyJkb2MjbW9yZUxpa2VUaGlzMSJd",
+          "cursor": "WyJtb3JlTGlrZVRoaXMxIl0=",
           "node": Object {
             "id": "moreLikeThis1",
           },
         },
       ],
       "pageInfo": Object {
-        "firstCursor": "WyJkb2MjdXNlckZvbyJd",
-        "lastCursor": "WyJkb2MjbW9yZUxpa2VUaGlzMSJd",
+        "firstCursor": "WyJ1c2VyRm9vIl0=",
+        "lastCursor": "WyJtb3JlTGlrZVRoaXMxIl0=",
       },
       "totalCount": 4,
     },
@@ -146,8 +146,8 @@ Object {
         },
       ],
       "pageInfo": Object {
-        "firstCursor": "WzQsImRvYyN1c2VyRm9vIl0=",
-        "lastCursor": "WzEsImRvYyNydW1vciJd",
+        "firstCursor": "WzQsInVzZXJGb28iXQ==",
+        "lastCursor": "WzEsInJ1bW9yIl0=",
       },
       "totalCount": 4,
     },
@@ -167,8 +167,8 @@ Object {
         },
       ],
       "pageInfo": Object {
-        "firstCursor": "WyJkb2MjdXNlckZvbyJd",
-        "lastCursor": "WyJkb2MjbW9yZUxpa2VUaGlzMSJd",
+        "firstCursor": "WyJ1c2VyRm9vIl0=",
+        "lastCursor": "WyJtb3JlTGlrZVRoaXMxIl0=",
       },
       "totalCount": 4,
     },
@@ -198,8 +198,8 @@ Object {
         },
       ],
       "pageInfo": Object {
-        "firstCursor": "WyJkb2MjdXNlckZvbyJd",
-        "lastCursor": "WyJkb2MjbW9yZUxpa2VUaGlzMSJd",
+        "firstCursor": "WyJ1c2VyRm9vIl0=",
+        "lastCursor": "WyJtb3JlTGlrZVRoaXMxIl0=",
       },
       "totalCount": 4,
     },

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -34,7 +34,7 @@ export function getOperatorAndOperand(expression) {
   } else if (typeof expression.GT !== 'undefined') {
     return { operator: '>', operand: expression.GT };
   }
-  return {};
+  throw new Error('Invalid Expression!');
 }
 
 export function createFilterType(typeName, args) {

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -106,7 +106,7 @@ export function getSortArgs(orderBy, fieldFnMap = {}) {
 
       return (fieldFnMap[field] || defaultFieldFn)(order);
     })
-    .concat({ _uid: { order: 'desc' } }); // enforce at least 1 sort order for pagination
+    .concat({ _id: { order: 'desc' } }); // enforce at least 1 sort order for pagination
 }
 
 // sort: [{fieldName: {order: 'desc'}}, {fieldName2: {order: 'desc'}}, ...]


### PR DESCRIPTION
#92.
We're using _id (`<id>`) instead of _uid (`<type>#<id>`) for sorting, so the cursors are also changed.

One thing that I don't understand is in `/src/util/client.js` at line 22, you used `sort` as the cursor. Why don't you use `id`?