### PR TITLE
Scrap URLs when articles are submitted

### DIFF
--- a/src/graphql/dataLoaders/urlLoaderFactory.js
+++ b/src/graphql/dataLoaders/urlLoaderFactory.js
@@ -4,29 +4,24 @@ import DataLoader from 'dataloader';
  * Given list of urls, return their latest fetch respectively
  */
 export default dataLoaders =>
-  new DataLoader(
-    async urls => {
-      const data = await dataLoaders.searchResultLoader.loadMany(
-        urls.map(url => ({
-          index: 'urls',
-          type: 'doc',
-          body: {
-            query: {
-              bool: {
-                should: [{ term: { url } }, { term: { canonical: url } }],
-              },
+  new DataLoader(async urls => {
+    const data = await dataLoaders.searchResultLoader.loadMany(
+      urls.map(url => ({
+        index: 'urls',
+        type: 'doc',
+        body: {
+          query: {
+            bool: {
+              should: [{ term: { url } }, { term: { canonical: url } }],
             },
-            sort: {
-              fetchedAt: 'desc',
-            },
-            size: 1,
           },
-        }))
-      );
+          sort: {
+            fetchedAt: 'desc',
+          },
+          size: 1,
+        },
+      }))
+    );
 
-      return data.map(result => (result && result.length ? result[0] : null));
-    },
-    {
-      cacheKeyFn: JSON.stringify,
-    }
-  );
+    return data.map(result => (result && result.length ? result[0] : null));
+  });

--- a/src/graphql/mutations/CreateArticle.js
+++ b/src/graphql/mutations/CreateArticle.js
@@ -130,7 +130,7 @@ export default {
   resolve(rootValue, { text, reference, reason }, { appId, userId, loaders }) {
     assertUser({ appId, userId });
 
-    const createNewArticlePromise = createNewArticle({
+    const newArticlePromise = createNewArticle({
       text,
       reference,
       userId,
@@ -150,19 +150,19 @@ export default {
     //
 
     const hyperlinkPromise = Promise.all([
-      createNewArticlePromise,
+      newArticlePromise,
       scrapPromise,
     ]).then(([articleId, scrapResults]) => {
       return updateArticleHyperlinks(articleId, scrapResults);
     });
 
-    const replyRequestPromise = createNewArticlePromise.then(articleId =>
+    const replyRequestPromise = newArticlePromise.then(articleId =>
       createReplyRequest({ articleId, userId, appId, reason })
     );
 
     // Wait for all promises
     return Promise.all([
-      createNewArticlePromise, // for fetching articleId
+      newArticlePromise, // for fetching articleId
       hyperlinkPromise,
       replyRequestPromise,
     ]).then(([id]) => ({ id }));

--- a/src/graphql/mutations/CreateArticle.js
+++ b/src/graphql/mutations/CreateArticle.js
@@ -93,11 +93,12 @@ async function createNewArticle({
 /**
  * @param {string} articleId
  * @param {ScrapResult[]} hyperlinks
+ * @return {Promise} update result
  */
-async function updateArticleHyperlinks(articleId, scrapResults) {
+function updateArticleHyperlinks(articleId, scrapResults) {
   if (!scrapResults || scrapResults.length === 0) return;
 
-  await client.update({
+  return client.update({
     index: 'articles',
     type: 'doc',
     id: articleId,

--- a/src/graphql/mutations/CreateArticle.js
+++ b/src/graphql/mutations/CreateArticle.js
@@ -144,9 +144,9 @@ export default {
 
     // Dependencies
     //
-    // createNewArticlePromise --> createReplyRequest -------.
-    //                        \                               >-> done
-    // scrapPromise -----------`-> updateArticleHyperlinks  -'
+    // newArticlePromise --> createReplyRequest -------.
+    //                  \                               >-> done
+    // scrapPromise -----`-> updateArticleHyperlinks  -'
     //
 
     const hyperlinkPromise = Promise.all([

--- a/src/graphql/mutations/CreateArticle.js
+++ b/src/graphql/mutations/CreateArticle.js
@@ -93,10 +93,10 @@ async function createNewArticle({
 /**
  * @param {string} articleId
  * @param {ScrapResult[]} hyperlinks
- * @return {Promise} update result
+ * @return {Promise | null} update result
  */
 function updateArticleHyperlinks(articleId, scrapResults) {
-  if (!scrapResults || scrapResults.length === 0) return;
+  if (!scrapResults || scrapResults.length === 0) return Promise.resolve(null);
 
   return client.update({
     index: 'articles',

--- a/src/graphql/mutations/CreateArticle.js
+++ b/src/graphql/mutations/CreateArticle.js
@@ -127,11 +127,7 @@ export default {
         'The reason why the user want to submit this article. Mandatory for 1st sender',
     },
   },
-  async resolve(
-    rootValue,
-    { text, reference, reason },
-    { appId, userId, loaders }
-  ) {
+  resolve(rootValue, { text, reference, reason }, { appId, userId, loaders }) {
     assertUser({ appId, userId });
 
     const createNewArticlePromise = createNewArticle({
@@ -164,12 +160,11 @@ export default {
       createReplyRequest({ articleId, userId, appId, reason })
     );
 
-    // Wait all before done
-    await hyperlinkPromise;
-    await replyRequestPromise;
-
-    // Return article id
-    const id = await createNewArticlePromise;
-    return { id };
+    // Wait for all promises
+    return Promise.all([
+      createNewArticlePromise, // for fetching articleId
+      hyperlinkPromise,
+      replyRequestPromise,
+    ]).then(([id]) => ({ id }));
   },
 };

--- a/src/graphql/mutations/CreateArticle.js
+++ b/src/graphql/mutations/CreateArticle.js
@@ -145,10 +145,14 @@ export default {
 
     // Dependencies
     //
-    // newArticlePromise --> createReplyRequest -------.
-    //                  \                               >-> done
-    // scrapPromise -----`-> updateArticleHyperlinks  -'
+    // newArticlePromise --> replyRequestPromise -.
+    //                  \                          >-> done
+    // scrapPromise -----`-> hyperlinkPromise ----'
     //
+
+    const replyRequestPromise = newArticlePromise.then(articleId =>
+      createReplyRequest({ articleId, userId, appId, reason })
+    );
 
     const hyperlinkPromise = Promise.all([
       newArticlePromise,
@@ -156,10 +160,6 @@ export default {
     ]).then(([articleId, scrapResults]) => {
       return updateArticleHyperlinks(articleId, scrapResults);
     });
-
-    const replyRequestPromise = newArticlePromise.then(articleId =>
-      createReplyRequest({ articleId, userId, appId, reason })
-    );
 
     // Wait for all promises
     return Promise.all([

--- a/src/graphql/mutations/__fixtures__/CreateArticle.js
+++ b/src/graphql/mutations/__fixtures__/CreateArticle.js
@@ -14,4 +14,10 @@ export default {
     replyRequestCount: 1,
     references: [{ type: 'LINE' }],
   },
+  '/urls/doc/hyperlink1': {
+    canonical: 'http://foo.com/article/1',
+    title: 'FOO title',
+    summary: 'FOO article content',
+    url: 'http://foo.com/article/1-super-long-url-for-SEO',
+  },
 };

--- a/src/graphql/mutations/__tests__/CreateArticle.js
+++ b/src/graphql/mutations/__tests__/CreateArticle.js
@@ -6,128 +6,129 @@ import fixtures, { fixture1Text } from '../__fixtures__/CreateArticle';
 import { getReplyRequestId } from '../CreateReplyRequest';
 import { getArticleId } from 'graphql/mutations/CreateArticle';
 
-it('creates articles and a reply request', async () => {
-  MockDate.set(1485593157011);
-  const userId = 'test';
-  const appId = 'foo';
+describe('creation', () => {
+  beforeEach(() => loadFixtures(fixtures));
+  afterEach(() => unloadFixtures(fixtures));
 
-  const { data, errors } = await gql`
-    mutation($text: String!, $reference: ArticleReferenceInput!) {
-      CreateArticle(
-        text: $text
-        reference: $reference
-        reason: "気になります"
-      ) {
-        id
+  it('creates articles and a reply request and fills in URLs', async () => {
+    MockDate.set(1485593157011);
+    const userId = 'test';
+    const appId = 'foo';
+
+    const { data, errors } = await gql`
+      mutation($text: String!, $reference: ArticleReferenceInput!) {
+        CreateArticle(
+          text: $text
+          reference: $reference
+          reason: "気になります"
+        ) {
+          id
+        }
       }
-    }
-  `(
-    {
-      text: 'FOO FOO',
-      reference: { type: 'LINE' },
-    },
-    { userId, appId }
-  );
-  MockDate.reset();
+    `(
+      {
+        text: 'FOO FOO http://foo.com/article/1',
+        reference: { type: 'LINE' },
+      },
+      { userId, appId }
+    );
+    MockDate.reset();
 
-  expect(errors).toBeUndefined();
+    expect(errors).toBeUndefined();
 
-  const { _source: article } = await client.get({
-    index: 'articles',
-    type: 'doc',
-    id: data.CreateArticle.id,
+    const { _source: article } = await client.get({
+      index: 'articles',
+      type: 'doc',
+      id: data.CreateArticle.id,
+    });
+
+    expect(article.replyRequestCount).toBe(1);
+    expect(article).toMatchSnapshot();
+
+    const replyRequestId = getReplyRequestId({
+      articleId: data.CreateArticle.id,
+      userId,
+      appId,
+    });
+
+    const { _source: replyRequest } = await client.get({
+      index: 'replyrequests',
+      type: 'doc',
+      id: replyRequestId,
+    });
+
+    expect(replyRequest).toMatchSnapshot();
+
+    // Cleanup
+    await client.delete({
+      index: 'articles',
+      type: 'doc',
+      id: data.CreateArticle.id,
+    });
+
+    await client.delete({
+      index: 'replyrequests',
+      type: 'doc',
+      id: replyRequestId,
+    });
   });
 
-  expect(article.replyRequestCount).toBe(1);
-  expect(article).toMatchSnapshot();
+  it('avoids creating duplicated articles and adds replyRequests automatically', async () => {
+    MockDate.set(1485593157011);
+    const userId = 'test';
+    const appId = 'foo';
+    const articleId = getArticleId(fixture1Text);
 
-  const replyRequestId = getReplyRequestId({
-    articleId: data.CreateArticle.id,
-    userId,
-    appId,
-  });
-
-  const { _source: replyRequest } = await client.get({
-    index: 'replyrequests',
-    type: 'doc',
-    id: replyRequestId,
-  });
-
-  expect(replyRequest).toMatchSnapshot();
-
-  // Cleanup
-  await client.delete({
-    index: 'articles',
-    type: 'doc',
-    id: data.CreateArticle.id,
-  });
-
-  await client.delete({
-    index: 'replyrequests',
-    type: 'doc',
-    id: replyRequestId,
-  });
-});
-
-it('avoids creating duplicated articles and adds replyRequests automatically', async () => {
-  await loadFixtures(fixtures);
-
-  MockDate.set(1485593157011);
-  const userId = 'test';
-  const appId = 'foo';
-  const articleId = getArticleId(fixture1Text);
-
-  const { data, errors } = await gql`
-    mutation($text: String!, $reference: ArticleReferenceInput!) {
-      CreateArticle(
-        text: $text
-        reference: $reference
-        reason: "気になります"
-      ) {
-        id
+    const { data, errors } = await gql`
+      mutation($text: String!, $reference: ArticleReferenceInput!) {
+        CreateArticle(
+          text: $text
+          reference: $reference
+          reason: "気になります"
+        ) {
+          id
+        }
       }
-    }
-  `(
-    {
-      text: fixture1Text,
-      reference: { type: 'LINE' },
-    },
-    { userId, appId }
-  );
-  MockDate.reset();
-  expect(errors).toBeUndefined();
+    `(
+      {
+        text: fixture1Text,
+        reference: { type: 'LINE' },
+      },
+      { userId, appId }
+    );
+    MockDate.reset();
+    expect(errors).toBeUndefined();
 
-  // Expects no new article is created,
-  // and it returns the existing ID
-  expect(data.CreateArticle.id).toBe(articleId);
+    // Expects no new article is created,
+    // and it returns the existing ID
+    expect(data.CreateArticle.id).toBe(articleId);
 
-  const { _source: article } = await client.get({
-    index: 'articles',
-    type: 'doc',
-    id: articleId,
+    const { _source: article } = await client.get({
+      index: 'articles',
+      type: 'doc',
+      id: articleId,
+    });
+
+    // Expects lastRequestedAt, references are updated
+    expect(article).toMatchSnapshot();
+
+    // Expects new replyRequest is generated
+    const replyRequestId = getReplyRequestId({ articleId, appId, userId });
+    const { _source: replyRequest } = await client.get({
+      index: 'replyrequests',
+      type: 'doc',
+      id: replyRequestId,
+    });
+
+    expect(replyRequest).toMatchSnapshot();
+
+    // Cleanup
+    await client.delete({
+      index: 'replyrequests',
+      type: 'doc',
+      id: replyRequestId,
+    });
   });
-
-  // Expects lastRequestedAt, references are updated
-  expect(article).toMatchSnapshot();
-
-  // Expects new replyRequest is generated
-  const replyRequestId = getReplyRequestId({ articleId, appId, userId });
-  const { _source: replyRequest } = await client.get({
-    index: 'replyrequests',
-    type: 'doc',
-    id: replyRequestId,
-  });
-
-  expect(replyRequest).toMatchSnapshot();
-
-  // Cleanup
-  await client.delete({
-    index: 'replyrequests',
-    type: 'doc',
-    id: replyRequestId,
-  });
-
-  await unloadFixtures(fixtures);
 });
 
 const testId = async (userId, appId) => {

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateArticle.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateArticle.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`avoids creating duplicated articles and adds replyRequests automatically 1`] = `
+exports[`creation avoids creating duplicated articles and adds replyRequests automatically 1`] = `
 Object {
   "lastRequestedAt": "2017-01-28T08:45:57.011Z",
   "references": Array [
@@ -20,7 +20,7 @@ Object {
 }
 `;
 
-exports[`avoids creating duplicated articles and adds replyRequests automatically 2`] = `
+exports[`creation avoids creating duplicated articles and adds replyRequests automatically 2`] = `
 Object {
   "appId": "foo",
   "articleId": "20xz7y20qzyt6",
@@ -34,11 +34,18 @@ Object {
 }
 `;
 
-exports[`creates articles and a reply request 1`] = `
+exports[`creation creates articles and a reply request and fills in URLs 1`] = `
 Object {
   "appId": "foo",
   "articleReplies": Array [],
   "createdAt": "2017-01-28T08:45:57.011Z",
+  "hyperlinks": Array [
+    Object {
+      "summary": "FOO article content",
+      "title": "FOO title",
+      "url": "http://foo.com/article/1",
+    },
+  ],
   "lastRequestedAt": "2017-01-28T08:45:57.011Z",
   "normalArticleReplycount": 0,
   "references": Array [
@@ -51,16 +58,16 @@ Object {
   ],
   "replyRequestCount": 1,
   "tags": Array [],
-  "text": "FOO FOO",
+  "text": "FOO FOO http://foo.com/article/1",
   "updatedAt": "2017-01-28T08:45:57.011Z",
   "userId": "test",
 }
 `;
 
-exports[`creates articles and a reply request 2`] = `
+exports[`creation creates articles and a reply request and fills in URLs 2`] = `
 Object {
   "appId": "foo",
-  "articleId": "mdw91a2ngnnt",
+  "articleId": "y0iq3fr2pqgi",
   "createdAt": "2017-01-28T08:45:57.011Z",
   "feedbacks": Array [],
   "negativeFeedbackCount": 0,

--- a/src/util/__tests__/__snapshots__/scrapUrls.js.snap
+++ b/src/util/__tests__/__snapshots__/scrapUrls.js.snap
@@ -26,7 +26,7 @@ Array [
     "id": "someUrl-2nd-fetch",
     "summary": "Changed summary",
     "title": "Changed title",
-    "url": "http://example.com/article/1111-aaaaa-bbb-ccc",
+    "url": "http://example.com/article/1111",
   },
 ]
 `;

--- a/src/util/scrapUrls.js
+++ b/src/util/scrapUrls.js
@@ -136,7 +136,13 @@ async function scrapUrls(text, { cacheLoader, client, noFetch = false } = {}) {
     urls.map(async url => {
       if (cacheLoader) {
         const result = await cacheLoader.load(url);
-        if (result) return { ...result, fromUrlsCache: true };
+
+        if (result)
+          return {
+            ...result,
+            url, // Overwrite the URL from cache with the actual url in text, because cacheLoader may match canonical URLs
+            fromUrlsCache: true,
+          };
       }
 
       if (noFetch) return null;


### PR DESCRIPTION
This PR makes sure `CreateArticle` calls would invoke `scrapUrls` over the submitted text so that all the URLs in the submitted messages can be scrapped, also fills in its `hyperlinks` field for future searches.

Related to #41 

# Major changes
- Add `scrapUrls` to `CreateArticle` to fill `hyperlinks` field

# Minor changes
- Remove unnecessary `cacheKeyFn` from `urlLoaderFactory` because URL strings are already serializable
- Alter `scrapUrls` so that the returned `url` in `ScrapResult` always matches the one in input text