### PR TITLE
Scrap URLs when replies are submitted

### DIFF
--- a/src/graphql/mutations/__fixtures__/CreateReply.js
+++ b/src/graphql/mutations/__fixtures__/CreateReply.js
@@ -4,4 +4,10 @@ export default {
     articleReplies: [],
     references: [{ type: 'LINE' }],
   },
+  '/urls/doc/hyperlink1': {
+    canonical: 'http://google.com',
+    title: 'Google google',
+    summary: 'Gooooooogle',
+    url: 'http://google.com',
+  },
 };

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateReply.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateReply.js.snap
@@ -4,6 +4,13 @@ exports[`CreateReply creates replies and associates itself with specified articl
 Object {
   "appId": "test",
   "createdAt": "2017-01-28T08:45:57.011Z",
+  "hyperlinks": Array [
+    Object {
+      "summary": "Gooooooogle",
+      "title": "Google google",
+      "url": "http://google.com",
+    },
+  ],
   "reference": "http://google.com",
   "text": "FOO FOO",
   "type": "RUMOR",


### PR DESCRIPTION
CreateReply now also scraps URL in its text & references.

Related to #41, should be symmetrical with #97 