### PR TITLE
More fields to Hyperlink object type

### DIFF
--- a/src/graphql/models/Hyperlink.js
+++ b/src/graphql/models/Hyperlink.js
@@ -1,5 +1,12 @@
 import { GraphQLObjectType, GraphQLString } from 'graphql';
 
+function resolveUrl(field) {
+  return async function({ url }, args, { loaders }) {
+    const urlEntry = await loaders.urlLoader.load(url);
+    return urlEntry[field];
+  };
+}
+
 const Hyperlink = new GraphQLObjectType({
   name: 'Hyperlink',
   description: 'Data behind a hyperlink',
@@ -7,6 +14,9 @@ const Hyperlink = new GraphQLObjectType({
     url: { type: GraphQLString },
     title: { type: GraphQLString },
     summary: { type: GraphQLString },
+    topImageUrl: { type: GraphQLString, resolve: resolveUrl('topImageUrl') },
+    fetchedAt: { type: GraphQLString, resolve: resolveUrl('fetchedAt') },
+    status: { type: GraphQLString, resolve: resolveUrl('status') },
   },
 });
 

--- a/src/graphql/models/Hyperlink.js
+++ b/src/graphql/models/Hyperlink.js
@@ -17,6 +17,7 @@ const Hyperlink = new GraphQLObjectType({
     topImageUrl: { type: GraphQLString, resolve: resolveUrl('topImageUrl') },
     fetchedAt: { type: GraphQLString, resolve: resolveUrl('fetchedAt') },
     status: { type: GraphQLString, resolve: resolveUrl('status') },
+    error: { type: GraphQLString, resolve: resolveUrl('error') },
   },
 });
 

--- a/src/graphql/queries/__fixtures__/ListArticles.js
+++ b/src/graphql/queries/__fixtures__/ListArticles.js
@@ -50,11 +50,13 @@ export default {
     title: '馮諼很餓',
     summary:
       '居有頃，倚柱彈其劍，歌曰：「長鋏歸來乎！食無魚。」左右以告。孟嘗君曰：「食之，比門下之客。」',
+    topImageUrl: 'http://gohome.com/image.jpg',
   },
   '/urls/doc/biau': {
     url: 'http://出師表.com',
     title: '出師表',
     summary:
       '臣亮言：先帝創業未半，而中道崩殂。今天下三分，益州 疲弊，此誠危急存亡之秋也。',
+    topImageUrl: 'http://出師表.com/image.jpg',
   },
 };

--- a/src/graphql/queries/__tests__/ListArticles.js
+++ b/src/graphql/queries/__tests__/ListArticles.js
@@ -139,6 +139,10 @@ describe('ListArticles', () => {
             edges {
               node {
                 id
+                hyperlinks {
+                  summary
+                  topImageUrl
+                }
               }
             }
           }

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
@@ -56,11 +56,18 @@ Object {
       "edges": Array [
         Object {
           "node": Object {
+            "hyperlinks": Array [
+              Object {
+                "summary": "居有頃，倚柱彈其劍，歌曰：「長鋏歸來乎！食無魚。」左右以告。孟嘗君曰：「食之，比門下之客。」",
+                "topImageUrl": "http://gohome.com/image.jpg",
+              },
+            ],
             "id": "listArticleTest4",
           },
         },
         Object {
           "node": Object {
+            "hyperlinks": null,
             "id": "listArticleTest2",
           },
         },


### PR DESCRIPTION
This PR adds more field to `Hyperlink` object type by loading related field from `urls` index via dataloader.

Related to cofacts/rumors-site#102.