### PR TITLE
should also look up moreLikeThis text in hyperlinks

### DIFF
--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -139,19 +139,18 @@ export default {
         ...scrapResults.map(({ title, summary }) => `${title} ${summary}`),
       ];
 
-      shouldQueries.push({
-        more_like_this: {
-          fields: ['text'],
-          like: likeQuery,
-          min_term_freq: 1,
-          min_doc_freq: 1,
-          minimum_should_match:
-            filter.moreLikeThis.minimumShouldMatch || '10<70%',
+      shouldQueries.push(
+        {
+          more_like_this: {
+            fields: ['text'],
+            like: likeQuery,
+            min_term_freq: 1,
+            min_doc_freq: 1,
+            minimum_should_match:
+              filter.moreLikeThis.minimumShouldMatch || '10<70%',
+          },
         },
-      });
-
-      if (scrapResults.length > 0) {
-        shouldQueries.push({
+        {
           nested: {
             path: 'hyperlinks',
             score_mode: 'sum',
@@ -166,8 +165,8 @@ export default {
               },
             },
           },
-        });
-      }
+        }
+      );
     }
 
     if (filter.replyCount) {

--- a/src/graphql/queries/__fixtures__/ListReplies.js
+++ b/src/graphql/queries/__fixtures__/ListReplies.js
@@ -25,4 +25,31 @@ export default {
     type: 'RUMOR',
     createdAt: 1,
   },
+  '/replies/doc/referenceUrl': {
+    text: '國文課本',
+    reference: 'http://gohome.com',
+    hyperlinks: [
+      {
+        url: 'http://gohome.com',
+        title: '馮諼很餓',
+        summary:
+          '居有頃，倚柱彈其劍，歌曰：「長鋏歸來乎！食無魚。」左右以告。孟嘗君曰：「食之，比門下之客。」',
+      },
+    ],
+    type: 'NOT_RUMOR',
+    createdAt: 1,
+  },
+  '/urls/doc/gohome': {
+    url: 'http://gohome.com',
+    title: '馮諼很餓',
+    summary:
+      '居有頃，倚柱彈其劍，歌曰：「長鋏歸來乎！食無魚。」左右以告。孟嘗君曰：「食之，比門下之客。」',
+    topImageUrl: 'http://gohome.com/image.jpg',
+  },
+  '/urls/doc/foobar': {
+    url: 'http://foo.com',
+    title: 'bar',
+    summary: 'bar',
+    topImageUrl: 'http://foo.com/image.jpg',
+  },
 };

--- a/src/graphql/queries/__tests__/ListArticles.js
+++ b/src/graphql/queries/__tests__/ListArticles.js
@@ -98,7 +98,6 @@ describe('ListArticles', () => {
   it('filters by null operator', () => testReplyCount(''));
 
   it('filters by moreLikeThis', async () => {
-    // moreLikeThis query
     expect(
       await gql`
         {
@@ -127,9 +126,6 @@ describe('ListArticles', () => {
   });
 
   it('filters by moreLikeThis and given text, find articles containing hyperlinks with the said text', async () => {
-    // moreLikeThis query
-    // 1,
-    // 2.
     expect(
       await gql`
         query($like: String) {
@@ -157,10 +153,7 @@ describe('ListArticles', () => {
     ).toMatchSnapshot();
   });
 
-  it("filters by moreLikeThis and given URL, find articles with content the said URL's content", async () => {
-    // moreLikeThis query
-    // 1, given text, find articles containing hyperlinks with the said text
-    // 2. given URL, find articles with content the said URL's content
+  it("filters by moreLikeThis and given URL, find articles with the said URL's content", async () => {
     expect(
       await gql`
         query($like: String) {

--- a/src/graphql/queries/__tests__/ListArticles.js
+++ b/src/graphql/queries/__tests__/ListArticles.js
@@ -126,10 +126,10 @@ describe('ListArticles', () => {
     ).toMatchSnapshot();
   });
 
-  it('filters by moreLikeThis and handles URLs', async () => {
+  it('filters by moreLikeThis and given text, find articles containing hyperlinks with the said text', async () => {
     // moreLikeThis query
-    // 1, given text, find articles containing hyperlinks with the said text
-    // 2. given URL, find articles with content the said URL's content
+    // 1,
+    // 2.
     expect(
       await gql`
         query($like: String) {
@@ -152,7 +152,34 @@ describe('ListArticles', () => {
           1. text -> ariticles linked to the content
           居有頃，倚柱彈其劍，歌曰：「長鋏歸來乎！食無魚！」左右以告。孟嘗君曰：「食之
           ，比門下之客。」居有頃，復彈其鋏，歌曰：「長鋏歸來乎！出無車！」
+        `,
+      })
+    ).toMatchSnapshot();
+  });
 
+  it("filters by moreLikeThis and given URL, find articles with content the said URL's content", async () => {
+    // moreLikeThis query
+    // 1, given text, find articles containing hyperlinks with the said text
+    // 2. given URL, find articles with content the said URL's content
+    expect(
+      await gql`
+        query($like: String) {
+          ListArticles(
+            filter: { moreLikeThis: { like: $like, minimumShouldMatch: "5%" } }
+          ) {
+            edges {
+              node {
+                id
+                hyperlinks {
+                  summary
+                  topImageUrl
+                }
+              }
+            }
+          }
+        }
+      `({
+        like: `
           2. URL -> article with given URL's content
           http://出師表.com
         `,

--- a/src/graphql/queries/__tests__/ListReplies.js
+++ b/src/graphql/queries/__tests__/ListReplies.js
@@ -116,6 +116,47 @@ describe('ListReplies', () => {
     ).toMatchSnapshot();
   });
 
+  it('filters by moreLikeThis and given text, find replies containing hyperlinks with the said text', async () => {
+    expect(
+      await gql`
+        {
+          ListReplies(
+            filter: { moreLikeThis: { like: "「長鋏歸來乎！食無魚。」" } }
+          ) {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      `()
+    ).toMatchSnapshot();
+  });
+
+  it("filters by moreLikeThis and given text, find replies with the said URL's content", async () => {
+    expect(
+      await gql`
+        {
+          ListReplies(
+            filter: {
+              moreLikeThis: {
+                like: "請看 http://foo.com"
+                minimumShouldMatch: "5%"
+              }
+            }
+          ) {
+            edges {
+              node {
+                id
+              }
+            }
+          }
+        }
+      `()
+    ).toMatchSnapshot();
+  });
+
   it('supports after', async () => {
     expect(
       await gql`

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
@@ -49,7 +49,7 @@ Object {
 }
 `;
 
-exports[`ListArticles filters by moreLikeThis and given URL, find articles with content the said URL's content 1`] = `
+exports[`ListArticles filters by moreLikeThis and given URL, find articles with the said URL's content 1`] = `
 Object {
   "data": Object {
     "ListArticles": Object {

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
@@ -49,7 +49,24 @@ Object {
 }
 `;
 
-exports[`ListArticles filters by moreLikeThis and handles URLs 1`] = `
+exports[`ListArticles filters by moreLikeThis and given URL, find articles with content the said URL's content 1`] = `
+Object {
+  "data": Object {
+    "ListArticles": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "hyperlinks": null,
+            "id": "listArticleTest2",
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`ListArticles filters by moreLikeThis and given text, find articles containing hyperlinks with the said text 1`] = `
 Object {
   "data": Object {
     "ListArticles": Object {
@@ -63,12 +80,6 @@ Object {
               },
             ],
             "id": "listArticleTest4",
-          },
-        },
-        Object {
-          "node": Object {
-            "hyperlinks": null,
-            "id": "listArticleTest2",
           },
         },
       ],

--- a/src/graphql/queries/__tests__/__snapshots__/ListReplies.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListReplies.js.snap
@@ -68,6 +68,43 @@ Object {
 }
 `;
 
+exports[`ListReplies filters by moreLikeThis and given text, find replies containing hyperlinks with the said text 1`] = `
+Object {
+  "data": Object {
+    "ListReplies": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "referenceUrl",
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`ListReplies filters by moreLikeThis and given text, find replies with the said URL's content 1`] = `
+Object {
+  "data": Object {
+    "ListReplies": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "userFoo",
+          },
+        },
+        Object {
+          "node": Object {
+            "id": "rumor",
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`ListReplies handles selfOnly filter properly if not logged in 1`] = `
 Object {
   "data": Object {
@@ -97,6 +134,12 @@ Object {
           },
         },
         Object {
+          "cursor": "WyJyZWZlcmVuY2VVcmwiXQ==",
+          "node": Object {
+            "id": "referenceUrl",
+          },
+        },
+        Object {
           "cursor": "WyJtb3JlTGlrZVRoaXMyIl0=",
           "node": Object {
             "id": "moreLikeThis2",
@@ -113,7 +156,7 @@ Object {
         "firstCursor": "WyJ1c2VyRm9vIl0=",
         "lastCursor": "WyJtb3JlTGlrZVRoaXMxIl0=",
       },
-      "totalCount": 4,
+      "totalCount": 5,
     },
   },
 }
@@ -144,12 +187,17 @@ Object {
             "id": "rumor",
           },
         },
+        Object {
+          "node": Object {
+            "id": "referenceUrl",
+          },
+        },
       ],
       "pageInfo": Object {
         "firstCursor": "WzQsInVzZXJGb28iXQ==",
-        "lastCursor": "WzEsInJ1bW9yIl0=",
+        "lastCursor": "WzEsInJlZmVyZW5jZVVybCJd",
       },
-      "totalCount": 4,
+      "totalCount": 5,
     },
   },
 }
@@ -170,7 +218,7 @@ Object {
         "firstCursor": "WyJ1c2VyRm9vIl0=",
         "lastCursor": "WyJtb3JlTGlrZVRoaXMxIl0=",
       },
-      "totalCount": 4,
+      "totalCount": 5,
     },
   },
 }
@@ -193,6 +241,11 @@ Object {
         },
         Object {
           "node": Object {
+            "id": "referenceUrl",
+          },
+        },
+        Object {
+          "node": Object {
             "id": "moreLikeThis2",
           },
         },
@@ -201,7 +254,7 @@ Object {
         "firstCursor": "WyJ1c2VyRm9vIl0=",
         "lastCursor": "WyJtb3JlTGlrZVRoaXMxIl0=",
       },
-      "totalCount": 4,
+      "totalCount": 5,
     },
   },
 }


### PR DESCRIPTION
Although we have url preview implemented, it seems that searching text does not match the title and content in URL previews.

This is because `ListArticles` are implemented incorrectly.

This PR fixes the problem by always including `'hyperlinks.title` and `hyperlinks.summary` in the searched fields.

This PR also makes `ListReplies`'s `moreLikeThis` filter searches `hyperlinks` as well. Its implementation was omitted before.