### PR TITLE
Fix total count issue by ensuring the more_like_this also filters out non-matching items.

### DIFF
--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -204,6 +204,7 @@ export default {
         should:
           shouldQueries.length === 0 ? [{ match_all: {} }] : shouldQueries,
         filter: filterQueries,
+        minimum_should_match: 1, // At least 1 "should" query should present
       },
     };
 

--- a/src/graphql/queries/ListReplies.js
+++ b/src/graphql/queries/ListReplies.js
@@ -114,6 +114,7 @@ export default {
         should:
           shouldQueries.length === 0 ? [{ match_all: {} }] : shouldQueries,
         filter: filterQueries,
+        minimum_should_match: 1, // At least 1 "should" query should present
       },
     };
 

--- a/src/graphql/queries/__tests__/ListArticles.js
+++ b/src/graphql/queries/__tests__/ListArticles.js
@@ -232,6 +232,32 @@ describe('ListArticles', () => {
     ).toMatchSnapshot();
   });
 
+  it('filters by mixed query', async () => {
+    // Mixes 'should' and 'filter' query. At least 1 'should' must match.
+    // Therefore, this query should only match 1 result instead of all that satisfies replyRequestCount: { GT: 0 }
+    expect(
+      await gql`
+        {
+          ListArticles(
+            filter: {
+              moreLikeThis: {
+                like: "憶昔封書與君夜，金鑾殿後欲明天。今夜封書在何處？廬山庵裏曉燈前。籠鳥檻猿俱未死，人間相見是何年？"
+              }
+              replyRequestCount: { GT: 0 }
+            }
+          ) {
+            edges {
+              node {
+                id
+              }
+            }
+            totalCount
+          }
+        }
+      `()
+    ).toMatchSnapshot();
+  });
+
   it('throws error when author filter is not set correctly', async () => {
     const { errors: noUserIdError } = await gql`
       {

--- a/src/graphql/queries/__tests__/ListReplies.js
+++ b/src/graphql/queries/__tests__/ListReplies.js
@@ -157,6 +157,28 @@ describe('ListReplies', () => {
     ).toMatchSnapshot();
   });
 
+  it('filters by mixed query', async () => {
+    // Mixes 'should' and 'filter' query. At least 1 'should' must match.
+    // Therefore, this query should only match 2 results instead of all that satisfies type = NOT_ARTICLE
+
+    expect(
+      await gql`
+        {
+          ListReplies(
+            filter: { type: NOT_ARTICLE, moreLikeThis: { like: "foo" } }
+          ) {
+            edges {
+              node {
+                id
+              }
+            }
+            totalCount
+          }
+        }
+      `()
+    ).toMatchSnapshot();
+  });
+
   it('supports after', async () => {
     expect(
       await gql`

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
@@ -23,6 +23,23 @@ Object {
 }
 `;
 
+exports[`ListArticles filters by mixed query 1`] = `
+Object {
+  "data": Object {
+    "ListArticles": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "listArticleTest1",
+          },
+        },
+      ],
+      "totalCount": 1,
+    },
+  },
+}
+`;
+
 exports[`ListArticles filters by moreLikeThis 1`] = `
 Object {
   "data": Object {

--- a/src/graphql/queries/__tests__/__snapshots__/ListReplies.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListReplies.js.snap
@@ -68,6 +68,28 @@ Object {
 }
 `;
 
+exports[`ListReplies filters by mixed query 1`] = `
+Object {
+  "data": Object {
+    "ListReplies": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "moreLikeThis2",
+          },
+        },
+        Object {
+          "node": Object {
+            "id": "moreLikeThis1",
+          },
+        },
+      ],
+      "totalCount": 2,
+    },
+  },
+}
+`;
+
 exports[`ListReplies filters by moreLikeThis and given text, find replies containing hyperlinks with the said text 1`] = `
 Object {
   "data": Object {


### PR DESCRIPTION
Currently when `more_like_this` is used with other `filters`, the total count of the result would be the total number of items matching the filter, regardless of whether there is a match with `more_like_this`.

Actually it's a [document feature in `bool` query](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html) that allows no items in `should` clause to be included in the result:
> If the bool query is in a query context and has a must or filter clause then a document will match the bool query even if none of the should queries match.

This PR adds `minimum_should_match` to bool query so that the `more_like_this` query in `should` clause can take effect of filtering unmatched items.

Fixes #110 