### PR TITLE
When listing articles & replies, take urls into account

### DIFF
--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -167,6 +167,24 @@ export default {
           },
         }
       );
+
+      // Additionally, match the scrapped URLs with other article's scrapped urls
+      if (scrapResults.length > 0) {
+        shouldQueries.push({
+          nested: {
+            path: 'hyperlinks',
+            score_mode: 'sum',
+            query: {
+              terms: {
+                'hyperlinks.url': [
+                  ...scrapResults.map(({ url }) => url),
+                  ...scrapResults.map(({ canonical }) => canonical),
+                ],
+              },
+            },
+          },
+        });
+      }
     }
 
     if (filter.replyCount) {

--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -169,17 +169,23 @@ export default {
       );
 
       // Additionally, match the scrapped URLs with other article's scrapped urls
-      if (scrapResults.length > 0) {
+      //
+      const urls = scrapResults.reduce((urls, result) => {
+        if (!result) return urls;
+
+        if (result.url) urls.push(result.url);
+        if (result.canonical) urls.push(result.canonical);
+        return urls;
+      }, []);
+
+      if (urls.length > 0) {
         shouldQueries.push({
           nested: {
             path: 'hyperlinks',
             score_mode: 'sum',
             query: {
               terms: {
-                'hyperlinks.url': [
-                  ...scrapResults.map(({ url }) => url),
-                  ...scrapResults.map(({ canonical }) => canonical),
-                ],
+                'hyperlinks.url': urls,
               },
             },
           },

--- a/src/graphql/queries/ListReplies.js
+++ b/src/graphql/queries/ListReplies.js
@@ -94,6 +94,24 @@ export default {
           },
         }
       );
+
+      // Additionally, match the scrapped URLs with other replies's scrapped urls
+      if (scrapResults.length > 0) {
+        shouldQueries.push({
+          nested: {
+            path: 'hyperlinks',
+            score_mode: 'sum',
+            query: {
+              terms: {
+                'hyperlinks.url': [
+                  ...scrapResults.map(({ url }) => url),
+                  ...scrapResults.map(({ canonical }) => canonical),
+                ],
+              },
+            },
+          },
+        });
+      }
     }
 
     if (filter.type) {

--- a/src/graphql/queries/ListReplies.js
+++ b/src/graphql/queries/ListReplies.js
@@ -95,18 +95,24 @@ export default {
         }
       );
 
-      // Additionally, match the scrapped URLs with other replies's scrapped urls
-      if (scrapResults.length > 0) {
+      // Additionally, match the scrapped URLs with other reply's scrapped urls
+      //
+      const urls = scrapResults.reduce((urls, result) => {
+        if (!result) return urls;
+
+        if (result.url) urls.push(result.url);
+        if (result.canonical) urls.push(result.canonical);
+        return urls;
+      }, []);
+
+      if (urls.length > 0) {
         shouldQueries.push({
           nested: {
             path: 'hyperlinks',
             score_mode: 'sum',
             query: {
               terms: {
-                'hyperlinks.url': [
-                  ...scrapResults.map(({ url }) => url),
-                  ...scrapResults.map(({ canonical }) => canonical),
-                ],
+                'hyperlinks.url': urls,
               },
             },
           },


### PR DESCRIPTION
Fixes #113 .

<img width="909" alt="2018-11-07 2 44 33" src="https://user-images.githubusercontent.com/108608/48114898-d5d34080-e29b-11e8-8847-14ff5d5a88ac.png">


When searching, we should take URLs into account, i.e. put url search in the `should` queries.

This way articles with the same URL will be matched and will have higher score.

Thanks @linekin for the idea!!
<img width="346" alt="2018-11-07 2 48 01" src="https://user-images.githubusercontent.com/108608/48114981-277bcb00-e29c-11e8-8029-46158ebe9d29.png">
