### PR TITLE
Script that clean up urls index

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,3 +158,12 @@ $ node_modules/.bin/babel-node src/scripts/fillAllHyperlinks.js
 This script would scan for all articles & replies to fill in their `hyperlinks` field, also populates
 `urls` index. The `urls` index is used as cache. If an URL already exists in `urls`, it will not trigger
 HTTP request.
+
+### Clean up old `urls` entries that are not referenced by any article & reply
+
+The `urls` index serves as a cache of URL scrapper and will enlarge as `ListArticle` is invoked with
+URLs. The following script cleans up those `urls` that no article & reply currently uses.
+
+```
+$ docker-compose exec api node_modules/.bin/babel-node src/scripts/cleanupUrls.js
+```

--- a/src/scripts/__fixtures__/cleanupUrls.js
+++ b/src/scripts/__fixtures__/cleanupUrls.js
@@ -25,21 +25,26 @@ export default {
     url: 'processed.com',
     canonical: 'processed.com',
     [FLAG_FIELD]: true,
+    fetchedAt: '2018-01-01T00:00:00Z', // more than 1 day ago
   },
   '/urls/doc/url-foo': {
     url: 'foo.com',
     canonical: 'foo2.com',
+    fetchedAt: '2018-01-01T00:00:00Z', // more than 1 day ago
   },
   '/urls/doc/curl-foo': {
     url: 'foo2.com',
     canonical: 'foo.com',
+    fetchedAt: '2018-01-01T00:00:00Z', // more than 1 day ago
   },
   '/urls/doc/url-bar': {
     url: 'bar.com',
     canonical: 'bar2.com',
+    fetchedAt: '2018-01-01T00:00:00Z', // more than 1 day ago
   },
   '/urls/doc/curl-bar': {
     url: 'bar2.com',
     canonical: 'bar.com',
+    fetchedAt: '2018-01-01T00:00:00Z', // more than 1 day ago
   },
 };

--- a/src/scripts/__fixtures__/cleanupUrls.js
+++ b/src/scripts/__fixtures__/cleanupUrls.js
@@ -1,0 +1,45 @@
+import { FLAG_FIELD } from '../cleanupUrls';
+
+export default {
+  '/articles/doc/a1': {
+    userId: 'user1',
+    appId: 'app1',
+    hyperlinks: [{ url: 'foo.com' }],
+  },
+  '/replies/doc/r1': {
+    userId: 'user1',
+    appId: 'app1',
+    hyperlinks: [{ url: 'bar.com' }],
+  },
+  '/urls/doc/url-to-delete': {
+    url: 'm.not-exist.com',
+    canonical: 'not-exist.com',
+    fetchedAt: '2018-01-01T00:00:00Z', // more than 1 day ago
+  },
+  '/urls/doc/new-url': {
+    url: 'm.not-exist-yet.com',
+    canonical: 'not-exist-yet.com',
+    fetchedAt: new Date().toISOString(), // most recent
+  },
+  '/urls/doc/url-processed': {
+    url: 'processed.com',
+    canonical: 'processed.com',
+    [FLAG_FIELD]: true,
+  },
+  '/urls/doc/url-foo': {
+    url: 'foo.com',
+    canonical: 'foo2.com',
+  },
+  '/urls/doc/curl-foo': {
+    url: 'foo2.com',
+    canonical: 'foo.com',
+  },
+  '/urls/doc/url-bar': {
+    url: 'bar.com',
+    canonical: 'bar2.com',
+  },
+  '/urls/doc/curl-bar': {
+    url: 'bar2.com',
+    canonical: 'bar.com',
+  },
+};

--- a/src/scripts/__tests__/__snapshots__/cleanupUrls.js.snap
+++ b/src/scripts/__tests__/__snapshots__/cleanupUrls.js.snap
@@ -5,6 +5,11 @@ Array [
   Object {
     "_cursor": undefined,
     "_score": 1,
+    "id": "new-url",
+  },
+  Object {
+    "_cursor": undefined,
+    "_score": 1,
     "id": "url-processed",
     "isReferenced": true,
   },

--- a/src/scripts/__tests__/__snapshots__/cleanupUrls.js.snap
+++ b/src/scripts/__tests__/__snapshots__/cleanupUrls.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should clean up urls 1`] = `
+Array [
+  Object {
+    "_cursor": undefined,
+    "_score": 1,
+    "id": "url-processed",
+    "isReferenced": true,
+  },
+  Object {
+    "_cursor": undefined,
+    "_score": 1,
+    "id": "url-foo",
+    "isReferenced": true,
+  },
+  Object {
+    "_cursor": undefined,
+    "_score": 1,
+    "id": "curl-foo",
+    "isReferenced": true,
+  },
+  Object {
+    "_cursor": undefined,
+    "_score": 1,
+    "id": "url-bar",
+    "isReferenced": true,
+  },
+  Object {
+    "_cursor": undefined,
+    "_score": 1,
+    "id": "curl-bar",
+    "isReferenced": true,
+  },
+]
+`;

--- a/src/scripts/__tests__/cleanupUrls.js
+++ b/src/scripts/__tests__/cleanupUrls.js
@@ -1,0 +1,24 @@
+import { loadFixtures, unloadFixtures } from 'util/fixtures';
+import client, { processMeta } from 'util/client';
+import cleanupUrls, { FLAG_FIELD } from '../cleanupUrls';
+import fixtures from '../__fixtures__/cleanupUrls';
+
+it('should clean up urls', async () => {
+  await loadFixtures(fixtures);
+
+  await cleanupUrls();
+
+  const urlsResult = (await client.search({
+    index: 'urls',
+    body: {
+      query: {
+        match_all: {},
+      },
+      _source: [FLAG_FIELD],
+    },
+  })).hits.hits.map(processMeta);
+
+  expect(urlsResult).toMatchSnapshot();
+
+  await unloadFixtures(fixtures);
+});

--- a/src/scripts/cleanupUrls.js
+++ b/src/scripts/cleanupUrls.js
@@ -77,7 +77,7 @@ async function processFn(docs) {
           path: 'hyperlinks',
           query: {
             terms: {
-              'hyperlinks.url': [canonical, url],
+              'hyperlinks.url': [canonical, url].filter(u => u), // canonical may be empty...
             },
           },
         },

--- a/src/scripts/cleanupUrls.js
+++ b/src/scripts/cleanupUrls.js
@@ -65,6 +65,12 @@ async function processUrls(processFn) {
  * @param {Doc[]} docs - [{ _id, _source: {canonical, url} }]
  */
 async function processFn(docs) {
+  if (docs.length === 0) {
+    // eslint-disable-next-line no-console
+    console.info('No urls to process.');
+    return;
+  }
+
   //
   // First of all, figure out each "doc" if any of them are referred
   //

--- a/src/scripts/cleanupUrls.js
+++ b/src/scripts/cleanupUrls.js
@@ -27,6 +27,13 @@ async function processUrls(processFn) {
               field: FLAG_FIELD,
             },
           },
+          must: {
+            range: {
+              fetchedAt: {
+                lte: new Date(Date.now() - 86400 * 1000).toISOString(), // yesterday
+              },
+            },
+          },
         },
       },
       _source: ['url', 'canonical'],

--- a/src/scripts/cleanupUrls.js
+++ b/src/scripts/cleanupUrls.js
@@ -1,0 +1,106 @@
+import 'dotenv/config';
+import 'util/catchUnhandledRejection';
+
+import client from 'util/client';
+
+const FLAG_FIELD = 'isReferenced';
+
+/**
+ * Scrolls through urls to process and invoke processFn on them.
+ *
+ * @param {function} processFn (urlDocs) => Promise that resolves after process
+ */
+function processUrls(processFn) {
+  return async () => {
+    let scrollId,
+      processedCount = 0,
+      total = Infinity;
+
+    const { hits, _scroll_id } = await client.search({
+      index: 'urls',
+      scroll: '30s',
+      size: 100,
+      body: {
+        query: {
+          bool: {
+            must_not: {
+              exists: {
+                field: FLAG_FIELD,
+              },
+            },
+          },
+        },
+        _source: ['url', 'canonical'],
+      },
+    });
+    await processFn(hits.hits);
+    processedCount += hits.hits.length;
+    total = hits.total;
+    scrollId = _scroll_id;
+
+    while (processedCount < total) {
+      const { hits, _scroll_id } = await client.scroll({
+        scroll: '30s',
+        scrollId,
+      });
+      await processFn(hits.hits);
+      processedCount += hits.hits.length;
+      scrollId = _scroll_id;
+    }
+  };
+}
+
+function removeUnused() {
+  return async () => {};
+}
+
+/**
+ * @param {Doc[]} docs - [{ _id, _source: {canonical, url} }]
+ */
+async function processFn(docs) {
+  //
+  // First of all, figure out each "doc" if any of them are referred
+  //
+  const mSearchBody = [];
+  docs.forEach(({ _source: { canonical, url } }) => {
+    mSearchBody.push({ index: 'articles,replies' });
+    mSearchBody.push({
+      query: {
+        nested: {
+          path: 'hyperlinks',
+          query: {
+            terms: {
+              'hyperlinks.url': [canonical, url],
+            },
+          },
+        },
+      },
+      size: 0, // Only need total
+    });
+  });
+
+  /**
+   * mSearchResult: [{hits: {total: count}}, ...]
+   */
+  const mSearchResult = (await client.msearch({ body: mSearchBody })).responses;
+
+  //
+  // Then perform update / delete on each doc
+  //
+  const bulkBody = [];
+  docs.forEach(async ({ _id }, idx) => {
+    const isReferenced = mSearchResult[idx].hits.total > 0;
+    if (!isReferenced) {
+      bulkBody.push({ delete: { _index: 'urls', _type: 'doc', _id } });
+    } else {
+      bulkBody.push({ update: { _index: 'urls', _type: 'doc', _id } });
+      bulkBody.push({ doc: { [FLAG_FIELD]: true } });
+    }
+  });
+
+  await client.bulk({ body: bulkBody, refresh: 'true' });
+}
+
+Promise.resolve()
+  .then(processUrls(processFn))
+  .then(removeUnused());

--- a/src/scripts/cleanupUrls.js
+++ b/src/scripts/cleanupUrls.js
@@ -44,6 +44,9 @@ async function processUrls(processFn) {
   total = hits.total;
   scrollId = _scroll_id;
 
+  // eslint-disable-next-line no-console
+  console.info(`${processedCount} / ${total} Processed`);
+
   while (processedCount < total) {
     const { hits, _scroll_id } = await client.scroll({
       scroll: '30s',
@@ -52,6 +55,9 @@ async function processUrls(processFn) {
     await processFn(hits.hits);
     processedCount += hits.hits.length;
     scrollId = _scroll_id;
+
+    // eslint-disable-next-line no-console
+    console.info(`${processedCount} / ${total} Processed`);
   }
 }
 
@@ -99,7 +105,14 @@ async function processFn(docs) {
     }
   });
 
-  await client.bulk({ body: bulkBody, refresh: 'true' });
+  const bulkResult = await client.bulk({ body: bulkBody, refresh: 'true' });
+  const deleteCount = bulkResult.items.reduce(
+    (sum, obj) => (obj.delete && obj.delete.status === 200 ? sum + 1 : sum),
+    0
+  );
+
+  // eslint-disable-next-line no-console
+  console.info(`... ${deleteCount} urls successfully deleted`);
 }
 
 async function main() {


### PR DESCRIPTION
Fixes #119 .

It does a sweep & update / delete operation on all urls that are both
1. not scanned before.
2. more than 1 day old

## Screenshot

Outputs are like:
![2019-01-14 2 20 40](https://user-images.githubusercontent.com/108608/51098804-db9f5200-1807-11e9-95da-8410a45cf765.png)

When most of the urls are referenced, writing `isReferenced: true`:
![processing](https://user-images.githubusercontent.com/108608/51098925-81eb5780-1808-11e9-94f6-b7b5fe66fa91.gif)

When most of the urls are deleted:
![delete](https://user-images.githubusercontent.com/108608/51099857-1310fd00-180e-11e9-9a4a-2a8a5a2e505e.gif)

Note that although we are not adding `isReferenced` explicitly to the index mapping, the elasticsearch can refer to the correct mapping type after execution:

```
~/workspace/rumors-api ➠ curl localhost:62222/urls?pretty=true
{
  "urls_v1_0_2" : {
    "aliases" : {
      "urls" : { }
    },
    "mappings" : {
      "doc" : {
        "properties" : {
          "isReferenced" : {
            "type" : "boolean"
          },
```