### PR TITLE
Fix issue #95 userLevel caches are wrong

### DIFF
--- a/src/graphql/dataLoaders/userLevelLoaderFactory.js
+++ b/src/graphql/dataLoaders/userLevelLoaderFactory.js
@@ -82,8 +82,5 @@ export default () =>
           };
         }
       );
-    },
-    {
-      cacheKeyFn: ({ index, id }) => `/${index}/${id}`,
     }
   );


### PR DESCRIPTION
Fixes #95 by removing cacheKeyFn.

The input of `userLevelLoader` will be `userId`(type:string), so we can just use default cache mechanism here.

-----
Here are my test logs and diff files using the query
```
{
  ListReplies {
    edges {
      cursor
      node {
        articleReplies {
          user {
            name
            id
            level
          }
        }
      }
    }
  }
}
```

[before-fix.diff](https://drive.google.com/file/d/1fN-dOIwYwRvm8mc-u4UiKldp37rUJBmK/view?usp=sharing) (just add some logs)
![before-log](https://user-images.githubusercontent.com/6376572/52103584-5ac2c180-2621-11e9-9d39-9a59ed710642.png)


[after-fix.diff](https://drive.google.com/file/d/1G3-rSpnYi0ni8baB6o1aAWMkAMQPLXTB/view?usp=sharing) (equals to default cache)
![after-log](https://user-images.githubusercontent.com/6376572/52103592-62826600-2621-11e9-990a-c514430de505.png)