### PR TITLE
Skip invalid scrapResults

### DIFF
--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -129,10 +129,10 @@ export default {
     }
 
     if (filter.moreLikeThis) {
-      const scrapResults = await scrapUrls(filter.moreLikeThis.like, {
+      const scrapResults = (await scrapUrls(filter.moreLikeThis.like, {
         client,
         cacheLoader: loaders.urlLoader,
-      });
+      })).filter(r => r);
 
       const likeQuery = [
         filter.moreLikeThis.like,

--- a/src/graphql/queries/ListReplies.js
+++ b/src/graphql/queries/ListReplies.js
@@ -56,10 +56,10 @@ export default {
     const filterQueries = []; // Not affects scores
 
     if (filter.moreLikeThis) {
-      const scrapResults = await scrapUrls(filter.moreLikeThis.like, {
+      const scrapResults = (await scrapUrls(filter.moreLikeThis.like, {
         client,
         cacheLoader: loaders.urlLoader,
-      });
+      })).filter(r => r);
 
       const likeQuery = [
         filter.moreLikeThis.like,


### PR DESCRIPTION
The recent occurence of LINE bot shows that ListArticle API sometimes failed to properly scrap URLs.

https://rollbar.com/mrorz/rumors-line-bot/items/19/
https://rollbar.com/mrorz/rumors-line-bot/items/151/

It causes:
```
[{"path": ["ListArticles"], "message": "Cannot destructure property `title` of 'undefined' or 'null'.", "extensions": {"code": "INTERNAL_SERVER_ERROR"}, "locations": [{"column": 7, "line": 3}], "authError": false}]
```

Then in term cuases:
```
TypeError: Cannot read property 'edges' of null (Most recent call first)

ListArticles.edges.length
```

However, scrapping should not interfere with ordinary searches. This PR filters out failed scrap results to fix the problem.

Related: https://github.com/cofacts/rumors-line-bot/issues/10

