### PR TITLE
Create or update feedback should return the entity with its feedback updated

### DIFF
--- a/src/graphql/models/ReplyRequest.js
+++ b/src/graphql/models/ReplyRequest.js
@@ -1,4 +1,5 @@
 import { GraphQLObjectType, GraphQLString, GraphQLInt } from 'graphql';
+import FeedbackVote from './FeedbackVote';
 
 export default new GraphQLObjectType({
   name: 'ReplyRequest',
@@ -27,5 +28,18 @@ export default new GraphQLObjectType({
     },
     createdAt: { type: GraphQLString },
     updatedAt: { type: GraphQLString },
+    ownVote: {
+      type: FeedbackVote,
+      description:
+        'The feedback of current user. null when not logged in or not voted yet.',
+      resolve({ feedbacks = [] }, args, { userId, appId }) {
+        if (!userId || !appId) return null;
+        const ownFeedback = feedbacks.find(
+          feedback => feedback.userId === userId && feedback.appId === appId
+        );
+        if (!ownFeedback) return null;
+        return ownFeedback.score;
+      },
+    },
   }),
 });

--- a/src/graphql/mutations/CreateOrUpdateArticleReplyFeedback.js
+++ b/src/graphql/mutations/CreateOrUpdateArticleReplyFeedback.js
@@ -1,12 +1,8 @@
-import {
-  GraphQLString,
-  GraphQLNonNull,
-  GraphQLInt,
-  GraphQLObjectType,
-} from 'graphql';
+import { GraphQLString, GraphQLNonNull } from 'graphql';
 
 import { assertUser } from 'graphql/util';
 import FeedbackVote from 'graphql/models/FeedbackVote';
+import ArticleReply from 'graphql/models/ArticleReply';
 
 import client from 'util/client';
 
@@ -21,14 +17,7 @@ export function getArticleReplyFeedbackId({
 
 export default {
   description: 'Create or update a feedback on an article-reply connection',
-  type: new GraphQLObjectType({
-    name: 'CreateOrUpdateArticleReplyFeedbackResult',
-    fields: {
-      feedbackCount: { type: GraphQLInt },
-      positiveFeedbackCount: { type: GraphQLInt },
-      negativeFeedbackCount: { type: GraphQLInt },
-    },
-  }),
+  type: ArticleReply,
   args: {
     articleId: { type: new GraphQLNonNull(GraphQLString) },
     replyId: { type: new GraphQLNonNull(GraphQLString) },
@@ -134,10 +123,8 @@ export default {
       );
     }
 
-    return {
-      feedbackCount: feedbacks.length,
-      negativeFeedbackCount,
-      positiveFeedbackCount,
-    };
+    return articleReplyUpdateResult.get._source.articleReplies.find(
+      articleReply => articleReply.replyId === replyId
+    );
   },
 };

--- a/src/graphql/mutations/CreateOrUpdateArticleReplyFeedback.js
+++ b/src/graphql/mutations/CreateOrUpdateArticleReplyFeedback.js
@@ -123,8 +123,16 @@ export default {
       );
     }
 
-    return articleReplyUpdateResult.get._source.articleReplies.find(
+    const updatedArticleReply = articleReplyUpdateResult.get._source.articleReplies.find(
       articleReply => articleReply.replyId === replyId
     );
+
+    if (!updatedArticleReply) {
+      throw new Error(
+        `Cannot get updated article reply with article ID = ${articleId} and reply ID = ${replyId}`
+      );
+    }
+
+    return { articleId, ...updatedArticleReply };
   },
 };

--- a/src/graphql/mutations/CreateOrUpdateArticleReplyFeedback.js
+++ b/src/graphql/mutations/CreateOrUpdateArticleReplyFeedback.js
@@ -117,6 +117,8 @@ export default {
       },
       _source: true,
     });
+
+    /* istanbul ignore if */
     if (articleReplyUpdateResult.result !== 'updated') {
       throw new Error(
         `Cannot article ${articleId}'s feedback count for feedback ID = ${id}`
@@ -127,6 +129,7 @@ export default {
       articleReply => articleReply.replyId === replyId
     );
 
+    /* istanbul ignore if */
     if (!updatedArticleReply) {
       throw new Error(
         `Cannot get updated article reply with article ID = ${articleId} and reply ID = ${replyId}`

--- a/src/graphql/mutations/CreateOrUpdateReplyRequestFeedback.js
+++ b/src/graphql/mutations/CreateOrUpdateReplyRequestFeedback.js
@@ -1,25 +1,14 @@
-import {
-  GraphQLString,
-  GraphQLNonNull,
-  GraphQLInt,
-  GraphQLObjectType,
-} from 'graphql';
+import { GraphQLString, GraphQLNonNull } from 'graphql';
 
 import { assertUser } from 'graphql/util';
 import FeedbackVote from 'graphql/models/FeedbackVote';
+import ReplyRequest from 'graphql/models/ReplyRequest';
 
 import client from 'util/client';
 
 export default {
   description: 'Create or update a feedback on a reply request reason',
-  type: new GraphQLObjectType({
-    name: 'CreateOrUpdateReplyRequestFeedbackResult',
-    fields: {
-      feedbackCount: { type: GraphQLInt },
-      positiveFeedbackCount: { type: GraphQLInt },
-      negativeFeedbackCount: { type: GraphQLInt },
-    },
-  }),
+  type: ReplyRequest,
   args: {
     replyRequestId: { type: new GraphQLNonNull(GraphQLString) },
     vote: { type: new GraphQLNonNull(FeedbackVote) },
@@ -30,9 +19,7 @@ export default {
     const now = new Date().toISOString();
 
     const {
-      get: {
-        _source: { positiveFeedbackCount, negativeFeedbackCount, feedbacks },
-      },
+      get: { _source },
     } = await client.update({
       index: 'replyrequests',
       type: 'doc',
@@ -86,10 +73,6 @@ export default {
       _source: true,
     });
 
-    return {
-      feedbackCount: feedbacks.length,
-      negativeFeedbackCount,
-      positiveFeedbackCount,
-    };
+    return _source;
   },
 };

--- a/src/graphql/mutations/__tests__/CreateOrUpdateArticleReplyFeedback.js
+++ b/src/graphql/mutations/__tests__/CreateOrUpdateArticleReplyFeedback.js
@@ -28,6 +28,10 @@ describe('CreateOrUpdateArticleReplyFeedback', () => {
           positiveFeedbackCount
           negativeFeedbackCount
           ownVote
+          feedbacks {
+            score
+            comment
+          }
         }
       }
     `(
@@ -91,6 +95,10 @@ describe('CreateOrUpdateArticleReplyFeedback', () => {
           positiveFeedbackCount
           negativeFeedbackCount
           ownVote
+          feedbacks {
+            score
+            comment
+          }
         }
       }
     `(

--- a/src/graphql/mutations/__tests__/CreateOrUpdateArticleReplyFeedback.js
+++ b/src/graphql/mutations/__tests__/CreateOrUpdateArticleReplyFeedback.js
@@ -27,6 +27,7 @@ describe('CreateOrUpdateArticleReplyFeedback', () => {
           feedbackCount
           positiveFeedbackCount
           negativeFeedbackCount
+          ownVote
         }
       }
     `(
@@ -89,6 +90,7 @@ describe('CreateOrUpdateArticleReplyFeedback', () => {
           feedbackCount
           positiveFeedbackCount
           negativeFeedbackCount
+          ownVote
         }
       }
     `(

--- a/src/graphql/mutations/__tests__/CreateOrUpdateReplyRequestFeedback.js
+++ b/src/graphql/mutations/__tests__/CreateOrUpdateReplyRequestFeedback.js
@@ -22,6 +22,7 @@ describe('CreateOrUpdateReplyRequestFeedback', () => {
           feedbackCount
           positiveFeedbackCount
           negativeFeedbackCount
+          ownVote
         }
       }
     `(
@@ -61,6 +62,7 @@ describe('CreateOrUpdateReplyRequestFeedback', () => {
           feedbackCount
           positiveFeedbackCount
           negativeFeedbackCount
+          ownVote
         }
       }
     `(

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateOrUpdateArticleReplyFeedback.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateOrUpdateArticleReplyFeedback.js.snap
@@ -4,6 +4,56 @@ exports[`CreateOrUpdateArticleReplyFeedback creates feedback on given article re
 Object {
   "CreateOrUpdateArticleReplyFeedback": Object {
     "feedbackCount": 12,
+    "feedbacks": Array [
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": "comment1",
+        "score": 1,
+      },
+    ],
     "negativeFeedbackCount": 0,
     "ownVote": "UPVOTE",
     "positiveFeedbackCount": 12,
@@ -38,6 +88,52 @@ exports[`CreateOrUpdateArticleReplyFeedback updates existing feedback 1`] = `
 Object {
   "CreateOrUpdateArticleReplyFeedback": Object {
     "feedbackCount": 11,
+    "feedbacks": Array [
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": 1,
+      },
+      Object {
+        "comment": null,
+        "score": -1,
+      },
+    ],
     "negativeFeedbackCount": 1,
     "ownVote": "DOWNVOTE",
     "positiveFeedbackCount": 10,

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateOrUpdateArticleReplyFeedback.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateOrUpdateArticleReplyFeedback.js.snap
@@ -5,6 +5,7 @@ Object {
   "CreateOrUpdateArticleReplyFeedback": Object {
     "feedbackCount": 12,
     "negativeFeedbackCount": 0,
+    "ownVote": "UPVOTE",
     "positiveFeedbackCount": 12,
   },
 }
@@ -38,6 +39,7 @@ Object {
   "CreateOrUpdateArticleReplyFeedback": Object {
     "feedbackCount": 11,
     "negativeFeedbackCount": 1,
+    "ownVote": "DOWNVOTE",
     "positiveFeedbackCount": 10,
   },
 }

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateOrUpdateReplyRequestFeedback.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateOrUpdateReplyRequestFeedback.js.snap
@@ -5,6 +5,7 @@ Object {
   "CreateOrUpdateReplyRequestFeedback": Object {
     "feedbackCount": 2,
     "negativeFeedbackCount": 0,
+    "ownVote": "UPVOTE",
     "positiveFeedbackCount": 2,
   },
 }
@@ -44,6 +45,7 @@ Object {
   "CreateOrUpdateReplyRequestFeedback": Object {
     "feedbackCount": 1,
     "negativeFeedbackCount": 1,
+    "ownVote": "DOWNVOTE",
     "positiveFeedbackCount": 0,
   },
 }


### PR DESCRIPTION
- `CreateOrUpdateReplyRequestFeedback` returns the target `ReplyRequest`
- `CreateOrUpdateArticleReplyFeedback` returns the target `ArticleReply`

The two API's original object type is a subset of `ReplyRequest` and `ArticleReply`, thus this PR does not introduce any breaking change.

In addition, this PR adds `ownVote` to `ReplyRequest` and `ArticleReply` so that API user can get the feedback of current user easily. It's used in [rumors-site](https://github.com/cofacts/rumors-site/blob/master/ducks/articleDetail.js#L297) as well.