### PR TITLE
Make sure CreateOrUpdate* APIs have ids correctly set in its result

### DIFF
--- a/src/graphql/mutations/CreateOrUpdateReplyRequestFeedback.js
+++ b/src/graphql/mutations/CreateOrUpdateReplyRequestFeedback.js
@@ -73,6 +73,6 @@ export default {
       _source: true,
     });
 
-    return _source;
+    return { ..._source, id: replyRequestId };
   },
 };

--- a/src/graphql/mutations/__tests__/CreateOrUpdateArticleReplyFeedback.js
+++ b/src/graphql/mutations/__tests__/CreateOrUpdateArticleReplyFeedback.js
@@ -24,6 +24,8 @@ describe('CreateOrUpdateArticleReplyFeedback', () => {
           vote: UPVOTE
           comment: $comment
         ) {
+          articleId
+          replyId
           feedbackCount
           positiveFeedbackCount
           negativeFeedbackCount
@@ -91,6 +93,8 @@ describe('CreateOrUpdateArticleReplyFeedback', () => {
           replyId: $replyId
           vote: DOWNVOTE
         ) {
+          articleId
+          replyId
           feedbackCount
           positiveFeedbackCount
           negativeFeedbackCount

--- a/src/graphql/mutations/__tests__/CreateOrUpdateReplyRequest.js
+++ b/src/graphql/mutations/__tests__/CreateOrUpdateReplyRequest.js
@@ -20,6 +20,7 @@ describe('CreateOrUpdateReplyRequest', () => {
           articleId: $articleId
           reason: "気になります"
         ) {
+          id
           replyRequestCount
           replyRequests {
             userId
@@ -81,6 +82,7 @@ describe('CreateOrUpdateReplyRequest', () => {
           articleId: $articleId
           reason: "New reason"
         ) {
+          id
           replyRequestCount
           replyRequests {
             userId

--- a/src/graphql/mutations/__tests__/CreateOrUpdateReplyRequestFeedback.js
+++ b/src/graphql/mutations/__tests__/CreateOrUpdateReplyRequestFeedback.js
@@ -19,6 +19,7 @@ describe('CreateOrUpdateReplyRequestFeedback', () => {
           replyRequestId: $replyRequestId
           vote: UPVOTE
         ) {
+          id
           feedbackCount
           positiveFeedbackCount
           negativeFeedbackCount
@@ -59,6 +60,7 @@ describe('CreateOrUpdateReplyRequestFeedback', () => {
           replyRequestId: $replyRequestId
           vote: DOWNVOTE
         ) {
+          id
           feedbackCount
           positiveFeedbackCount
           negativeFeedbackCount

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateOrUpdateArticleReplyFeedback.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateOrUpdateArticleReplyFeedback.js.snap
@@ -3,6 +3,7 @@
 exports[`CreateOrUpdateArticleReplyFeedback creates feedback on given article reply 1`] = `
 Object {
   "CreateOrUpdateArticleReplyFeedback": Object {
+    "articleId": "article1",
     "feedbackCount": 12,
     "feedbacks": Array [
       Object {
@@ -57,6 +58,7 @@ Object {
     "negativeFeedbackCount": 0,
     "ownVote": "UPVOTE",
     "positiveFeedbackCount": 12,
+    "replyId": "reply1",
   },
 }
 `;
@@ -87,6 +89,7 @@ Array [
 exports[`CreateOrUpdateArticleReplyFeedback updates existing feedback 1`] = `
 Object {
   "CreateOrUpdateArticleReplyFeedback": Object {
+    "articleId": "article1",
     "feedbackCount": 11,
     "feedbacks": Array [
       Object {
@@ -137,6 +140,7 @@ Object {
     "negativeFeedbackCount": 1,
     "ownVote": "DOWNVOTE",
     "positiveFeedbackCount": 10,
+    "replyId": "reply1",
   },
 }
 `;

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateOrUpdateReplyRequest.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateOrUpdateReplyRequest.js.snap
@@ -3,6 +3,7 @@
 exports[`CreateOrUpdateReplyRequest attaches a reply request to an article 1`] = `
 Object {
   "CreateOrUpdateReplyRequest": Object {
+    "id": "createReplyRequestTest1",
     "replyRequestCount": 2,
     "replyRequests": Array [
       Object {
@@ -40,6 +41,7 @@ Object {
 exports[`CreateOrUpdateReplyRequest can update reason of a previously submitted reply request 1`] = `
 Object {
   "CreateOrUpdateReplyRequest": Object {
+    "id": "createReplyRequestTest1",
     "replyRequestCount": 2,
     "replyRequests": Array [
       Object {

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateOrUpdateReplyRequestFeedback.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateOrUpdateReplyRequestFeedback.js.snap
@@ -4,6 +4,7 @@ exports[`CreateOrUpdateReplyRequestFeedback creates new feedback 1`] = `
 Object {
   "CreateOrUpdateReplyRequestFeedback": Object {
     "feedbackCount": 2,
+    "id": "foo",
     "negativeFeedbackCount": 0,
     "ownVote": "UPVOTE",
     "positiveFeedbackCount": 2,
@@ -44,6 +45,7 @@ exports[`CreateOrUpdateReplyRequestFeedback updates existing feedback 1`] = `
 Object {
   "CreateOrUpdateReplyRequestFeedback": Object {
     "feedbackCount": 1,
+    "id": "foo",
     "negativeFeedbackCount": 1,
     "ownVote": "DOWNVOTE",
     "positiveFeedbackCount": 0,


### PR DESCRIPTION
Currently `CreateOrUpdateReplyRequestFeedback` does not properly return the id of updated `ReplyRequest`. This PR adds the missing ID and adds test cases around all `CreateOrUpdate*` APIs to make sure that IDs are properly filled.