### PR TITLE
UpdateArticleReplyStatus should returns articleId correctly

### DIFF
--- a/src/graphql/mutations/UpdateArticleReplyStatus.js
+++ b/src/graphql/mutations/UpdateArticleReplyStatus.js
@@ -66,6 +66,7 @@ export default {
       );
     }
 
-    return _source.articleReplies;
+    // When returning, insert articleId so that ArticleReply object type can resolve article.
+    return _source.articleReplies.map(ar => ({ ...ar, articleId }));
   },
 };

--- a/src/graphql/mutations/__tests__/UpdateArticleReplyStatus.js
+++ b/src/graphql/mutations/__tests__/UpdateArticleReplyStatus.js
@@ -34,13 +34,15 @@ describe('UpdateArticleReplyStatus', () => {
     const userId = 'foo';
     const appId = 'test';
 
-    const { data } = await gql`
+    const { data, errors } = await gql`
       mutation {
         normal: UpdateArticleReplyStatus(
           articleId: "normal"
           replyId: "reply"
           status: DELETED
         ) {
+          articleId
+          replyId
           status
           updatedAt
         }
@@ -49,12 +51,15 @@ describe('UpdateArticleReplyStatus', () => {
           replyId: "reply"
           status: NORMAL
         ) {
+          articleId
+          replyId
           status
           updatedAt
         }
       }
     `({}, { userId, appId });
 
+    expect(errors).toBeUndefined();
     expect(data).toMatchSnapshot();
 
     const { _source: normal } = await client.get({

--- a/src/graphql/mutations/__tests__/__snapshots__/UpdateArticleReplyStatus.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/UpdateArticleReplyStatus.js.snap
@@ -10,12 +10,16 @@ exports[`UpdateArticleReplyStatus should set article reply fields correctly 1`] 
 Object {
   "deleted": Array [
     Object {
+      "articleId": "deleted",
+      "replyId": "reply",
       "status": "NORMAL",
       "updatedAt": "2017-01-28T08:45:57.011Z",
     },
   ],
   "normal": Array [
     Object {
+      "articleId": "normal",
+      "replyId": "reply",
       "status": "DELETED",
       "updatedAt": "2017-01-28T08:45:57.011Z",
     },


### PR DESCRIPTION
Previously `UpdateArticleReplyStatus` will return `null` for `ArticleReply`, which is wrong. This PR fixes the bug so that apollo-client works better.