### PR TITLE
Reorders result from gRPC to fulfill rule of Dataloader

### DIFF
--- a/src/util/__tests__/scrapUrls.js
+++ b/src/util/__tests__/scrapUrls.js
@@ -30,15 +30,7 @@ describe('scrapping & storage', () => {
       MockDate.set(1485593157011);
 
       resolveUrl.__addMockResponse([
-        {
-          url: 'http://example.com/index.html',
-          canonical: 'http://example.com/index.html',
-          title: 'Some title',
-          summary: 'Some text as summary',
-          topImageUrl: '',
-          html: '<html><head></head><body>Hello world</body></html>',
-          status: 200,
-        },
+        // Mimics the out-of-order nature of gRPC
         {
           url: 'http://example.com/not-found',
           canonical: 'http://example.com/not-found',
@@ -47,6 +39,15 @@ describe('scrapping & storage', () => {
           topImageUrl: '',
           html: '<html><head></head><body>Not Found</body></html>',
           status: 404,
+        },
+        {
+          url: 'http://example.com/index.html',
+          canonical: 'http://example.com/index.html',
+          title: 'Some title',
+          summary: 'Some text as summary',
+          topImageUrl: '',
+          html: '<html><head></head><body>Hello world</body></html>',
+          status: 200,
         },
       ]);
 

--- a/src/util/scrapUrls.js
+++ b/src/util/scrapUrls.js
@@ -32,7 +32,19 @@ async function scrapUrls(
   //
   const normalizedUrls = removeFBCLIDIfExist(originalUrls);
 
-  const scrapLoader = new DataLoader(urls => resolveUrl(urls));
+  const scrapLoader = new DataLoader(async urls => {
+    const urlToIndex = urls.reduce((map, url, i) => {
+      map[url] = i;
+      return map;
+    }, {});
+    const unorderedFetchResults = await resolveUrl(urls);
+    const orderedFetchResults = [];
+    unorderedFetchResults.forEach(
+      fetchResult =>
+        (orderedFetchResults[urlToIndex[fetchResult.url]] = fetchResult)
+    );
+    return orderedFetchResults;
+  });
 
   // result: list of ScrapResult, with its `url` being the url in text,
   // but canonical url may be normalized


### PR DESCRIPTION
gRPC calls will return out-of-order URL fetch results. This PR reorders the result from gRPC call using original URL order.

We first modify the unit test to create a failing test case:
![image](https://user-images.githubusercontent.com/108608/73593588-cb583300-4540-11ea-96e1-43d6e6d7ab48.png)
We can see that in the snapshot, fetch result of `http://example.com/not-found` was added to the entry for `http://example.com/index.html`, which reproduces the bug in #139.

After the implementation:
![image](https://user-images.githubusercontent.com/108608/73593580-b4b1dc00-4540-11ea-84b8-fbd42a517e26.png)

This fixes #139.

