### PR TITLE
Fix typo in article creation API

### DIFF
--- a/src/graphql/mutations/CreateArticle.js
+++ b/src/graphql/mutations/CreateArticle.js
@@ -78,7 +78,7 @@ async function createNewArticle({
         appId,
         references: [reference],
         articleReplies: [],
-        normalArticleReplycount: 0,
+        normalArticleReplyCount: 0,
         replyRequestCount: 0,
         tags: [],
         hyperlinks: [],

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateArticle.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateArticle.js.snap
@@ -48,7 +48,7 @@ Object {
     },
   ],
   "lastRequestedAt": "2017-01-28T08:45:57.011Z",
-  "normalArticleReplycount": 0,
+  "normalArticleReplyCount": 0,
   "references": Array [
     Object {
       "appId": "foo",


### PR DESCRIPTION
A typo is identified, which adds a useless field `normalArticleReplycount` to each `article` document. This PR sets the field correctly.