### PR TITLE
[CreateReply] allow skipping hyperlink resolving

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ services:
 
 language: node_js
 
-node_js: '10'
+node_js: '12'
 
 before_install:
   # Startup test db

--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
     "roots": [
       "src"
     ],
-    "setupFilesAfterEnv": ["./test/setup.js"]
+    "setupFilesAfterEnv": [
+      "./test/setup.js"
+    ]
   }
 }

--- a/src/graphql/models/Reply.js
+++ b/src/graphql/models/Reply.js
@@ -38,7 +38,8 @@ const Reply = new GraphQLObjectType({
     },
     hyperlinks: {
       type: new GraphQLList(Hyperlink),
-      description: 'Hyperlinks in reply text or reference',
+      description:
+        'Hyperlinks in reply text or reference. May be empty array if no URLs are included. `null` when hyperlinks are still fetching.',
     },
   }),
 });

--- a/src/graphql/mutations/CreateReply.js
+++ b/src/graphql/mutations/CreateReply.js
@@ -47,7 +47,7 @@ export default {
     waitForHyperlinks: {
       type: GraphQLBoolean,
       description:
-        'If CreateReplh should resolve after hyperlinks are resolved.',
+        'If CreateReply should resolve after hyperlinks are resolved.',
       defaultValue: false,
     },
   },

--- a/src/graphql/mutations/__tests__/CreateReply.js
+++ b/src/graphql/mutations/__tests__/CreateReply.js
@@ -83,6 +83,11 @@ describe('CreateReply', () => {
 
     // Cleanup
     await client.delete({ index: 'replies', type: 'doc', id: replyId });
+    await client.deleteByQuery({
+      index: 'urls',
+      type: 'doc',
+      body: { query: { term: { url: REF_URL } } },
+    });
     await resetFrom(fixtures, `/articles/doc/${articleId}`);
   });
 

--- a/src/graphql/mutations/__tests__/CreateReply.js
+++ b/src/graphql/mutations/__tests__/CreateReply.js
@@ -87,6 +87,7 @@ describe('CreateReply', () => {
       index: 'urls',
       type: 'doc',
       body: { query: { term: { url: REF_URL } } },
+      refresh: true,
     });
     await resetFrom(fixtures, `/articles/doc/${articleId}`);
   });

--- a/src/graphql/mutations/__tests__/CreateReply.js
+++ b/src/graphql/mutations/__tests__/CreateReply.js
@@ -13,7 +13,7 @@ describe('CreateReply', () => {
 
   it('creates replies and associates itself with specified article', async () => {
     MockDate.set(1485593157011);
-    const REF_URL = 'http://shouldscrap.com';
+    const REF_URL = 'http://shouldscrap.com/';
     const articleId = 'setReplyTest1';
     resolveUrl.__setDelay(500); // Scrap result delay for 500ms
     resolveUrl.__addMockResponse([
@@ -48,8 +48,6 @@ describe('CreateReply', () => {
       },
       { userId: 'test', appId: 'test' }
     );
-    MockDate.reset();
-    resolveUrl.__reset();
 
     expect(errors).toBeUndefined();
 
@@ -59,7 +57,7 @@ describe('CreateReply', () => {
       type: 'doc',
       id: replyId,
     });
-    expect(reply._source).toMatchSnapshot();
+    expect(reply._source).toMatchSnapshot('reply without hyperlinks');
 
     const article = await client.get({
       index: 'articles',
@@ -70,6 +68,8 @@ describe('CreateReply', () => {
 
     // Wait until urls are resolved
     await delayForMs(1000);
+    MockDate.reset();
+    resolveUrl.__reset();
 
     // Check replies and hyperlinks
     const replyAfterFetch = await client.get({

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateReply.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateReply.js.snap
@@ -4,6 +4,17 @@ exports[`CreateReply creates replies and associates itself with specified articl
 Object {
   "appId": "test",
   "createdAt": "2017-01-28T08:45:57.011Z",
+  "reference": "http://google.com",
+  "text": "FOO FOO",
+  "type": "RUMOR",
+  "userId": "test",
+}
+`;
+
+exports[`CreateReply should support waitForHyperlinks 1`] = `
+Object {
+  "appId": "test",
+  "createdAt": "2017-01-28T08:45:57.011Z",
   "hyperlinks": Array [
     Object {
       "normalizedUrl": "http://google.com/",
@@ -13,7 +24,7 @@ Object {
     },
   ],
   "reference": "http://google.com",
-  "text": "FOO FOO",
+  "text": "Bar Bar",
   "type": "RUMOR",
   "userId": "test",
 }

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateReply.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateReply.js.snap
@@ -1,10 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CreateReply creates replies and associates itself with specified article 1`] = `
+exports[`CreateReply creates replies and associates itself with specified article: hyperlinks after fetch 1`] = `
+Array [
+  Object {
+    "normalizedUrl": "http://shouldscrap.com/",
+    "title": "scrapped title",
+    "url": "http://shouldscrap.com/",
+  },
+]
+`;
+
+exports[`CreateReply creates replies and associates itself with specified article: reply without hyperlinks 1`] = `
 Object {
   "appId": "test",
   "createdAt": "2017-01-28T08:45:57.011Z",
-  "reference": "http://google.com",
+  "reference": "http://shouldscrap.com/",
   "text": "FOO FOO",
   "type": "RUMOR",
   "userId": "test",

--- a/src/util/__mocks__/grpc.js
+++ b/src/util/__mocks__/grpc.js
@@ -23,13 +23,13 @@ let mockResponses = [];
 let requests = [];
 let delayMs = 0; // milliseconds
 
-function resolveUrl(url) {
+function resolveUrl(urls) {
   if (!mockResponses[seq]) {
     throw Error(
       `resolveUrl Mock error: No response found for request #${seq}. Please add mock response first.`
     );
   }
-  requests.push(url);
+  requests.push(urls);
   return delayForMs(delayMs).then(() => mockResponses[seq++]);
 }
 

--- a/src/util/__mocks__/grpc.js
+++ b/src/util/__mocks__/grpc.js
@@ -1,10 +1,11 @@
 /**
  * Usage:
  *
- * jest.mock('path-to-resolveUrl/resolveUrl');
+ * jest.mock('path-to-grpc/grpc');
+ * import resolveUrl from 'path-to-grpc/grpc';
  *
  * it('some test', async () => {
- *   resolveUrl.__addMockResponse({data: {queryName: result})
+ *   resolveUrl.__addMockResponse([{url, ...}, ...])
  *
  *   const result = await functionUnderTestThatInvokesresolveUrl();
  *
@@ -15,9 +16,12 @@
  * })
  */
 
+import delayForMs from 'util/delayForMs';
+
 let seq = 0;
 let mockResponses = [];
 let requests = [];
+let delayMs = 0; // milliseconds
 
 function resolveUrl(url) {
   if (!mockResponses[seq]) {
@@ -26,15 +30,17 @@ function resolveUrl(url) {
     );
   }
   requests.push(url);
-  return Promise.resolve(mockResponses[seq++]);
+  return delayForMs(delayMs).then(() => mockResponses[seq++]);
 }
 
 resolveUrl.__addMockResponse = resp => mockResponses.push(resp);
+resolveUrl.__setDelay = delay => (delayMs = delay);
 resolveUrl.__getRequests = () => requests;
 resolveUrl.__reset = () => {
   seq = 0;
   mockResponses = [];
   requests = [];
+  delayMs = 0;
 };
 
 export default resolveUrl;

--- a/test/util/delayForMs.js
+++ b/test/util/delayForMs.js
@@ -1,0 +1,7 @@
+function delayForMs(delayMs) {
+  return new Promise(resolve => {
+    setTimeout(() => resolve(), delayMs);
+  });
+}
+
+export default delayForMs;

--- a/test/util/strings.js
+++ b/test/util/strings.js
@@ -1,7 +1,0 @@
-/* eslint import/prefer-default-export: off */
-
-export function truncate(text, size = 25) {
-  text = JSON.stringify(text);
-  if (text.length > size - 3) return `${text.slice(0, size - 3)}...`;
-  return text;
-}


### PR DESCRIPTION
As discussed in [20200212 meeting](https://g0v.hackmd.io/AwNFa7L1QKiBPziTtYva0A#CreateReply-%E4%B8%8D%E8%A6%81%E7%AD%89-url-resolving%EF%BC%8C%E6%9C%89%E6%99%82%E5%80%99%E9%82%84%E6%9C%83%E5%87%BA%E9%8C%AF), currently `CreateReply` API resolves after all URLs are resolved, which is error-prone and makes editors wait for a significant amount of time.

This PR allows users to skip resolution of hyperlinks by:
- Still executes hyperlink resolution, but skip waiting for the promise by default
- `hyperlinks` field in `Reply` doc is filled in after resolution. If no URLs, it will be filled in with empty array. UI can check `hyperlinks`'s type to determine if hyperlink resolution is finished.

## Refactor
Add custom timeout to `grpc` so that we can simulate asynchronous hyperlink resolution.

## TODO
We need to check existing `Reply` in the database to see if their `hyperlinks` are all filled in. If not, we may need to perform migration to fill in at least an empty array if no URLs are inside the reply.