### PR TITLE
Use range query for all artihmetic filters

### DIFF
--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -10,7 +10,7 @@ import {
   pagingArgs,
   getArithmeticExpressionType,
   getSortArgs,
-  getOperatorAndOperand,
+  getRangeFieldParamFromArithmeticExpression,
   createFilterType,
   createSortType,
   createConnectionType,
@@ -195,20 +195,14 @@ const Article = new GraphQLObjectType({
         if (filter.replyCount) {
           // Switch to bool query so that we can filter more_like_this results
           //
-          const { operator, operand } = getOperatorAndOperand(
-            filter.replyCount
-          );
           body.query = {
             bool: {
               must: body.query,
               filter: {
-                script: {
-                  script: {
-                    source: `doc['normalArticleReplyCount'].value ${operator} params.operand`,
-                    params: {
-                      operand,
-                    },
-                  },
+                range: {
+                  normalArticleReplyCount: getRangeFieldParamFromArithmeticExpression(
+                    filter.replyCount
+                  ),
                 },
               },
             },

--- a/src/graphql/queries/ListReplies.js
+++ b/src/graphql/queries/ListReplies.js
@@ -8,6 +8,7 @@ import {
   getSortArgs,
   pagingArgs,
   getArithmeticExpressionType,
+  getRangeFieldParamFromArithmeticExpression,
 } from 'graphql/util';
 import scrapUrls from 'util/scrapUrls';
 
@@ -145,16 +146,12 @@ export default {
     }
 
     if (filter.createdAt) {
-      // @todo: handle invalid type error?
-      // @todo: extract repetitive logic
-      const q = Object.fromEntries(
-        Object.entries(filter.createdAt)
-          .filter(([key]) => ['GT', 'GTE', 'LT', 'LTE'].includes(key))
-          .map(([key, value]) => [key.toLowerCase(), value])
-      );
-
       filterQueries.push({
-        range: { createdAt: q },
+        range: {
+          createdAt: getRangeFieldParamFromArithmeticExpression(
+            filter.createdAt
+          ),
+        },
       });
     }
 


### PR DESCRIPTION
Replaces `getOperatorAndOperand` & `script` queries with `getRangeFieldParamFromArithmeticExpression` and `range` queries for all filters involving "GT", "LT", "EQ".

Fixes #148 by picking up all arithmetic operations left out in previous PR (#154 )