### PR TITLE
implements hasArticleReplyWithMorePositiveFeedback on ListArticles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4503,7 +4503,7 @@
     },
     "@types/accepts": {
       "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
+      "resolved": "http://registry.npmjs.org/@types/accepts/-/accepts-1.3.5.tgz",
       "integrity": "sha512-jOdnI/3qTpHABjM5cx1Hc0sKsPoYCp+DP/GJRGtDlPd7fiV9oXGGIcjW/ZOxLIvjGz8MA+uMZI9metHlgqbgwQ==",
       "requires": {
         "@types/node": "*"
@@ -8555,9 +8555,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.0.2.tgz",
-      "integrity": "sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==",
+      "version": "14.6.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.6.0.tgz",
+      "integrity": "sha512-VKzfvHEKybTKjQVpTFrA5yUq2S9ihcZvfJAtsDBBCuV6wauPu1xl/f9ehgVf0FcEJJs4vz6ysb/ZMkGigQZseg==",
       "requires": {
         "iterall": "^1.2.2"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "elasticsearch": "^15.0.0",
     "form-data": "^3.0.0",
     "google-protobuf": "^3.0.0",
-    "graphql": "^14.0.0",
+    "graphql": "^14.6.0",
     "grpc": "^1.11.0",
     "kcors": "^2.2.1",
     "koa": "^2.5.0",

--- a/src/graphql/__tests__/util.js
+++ b/src/graphql/__tests__/util.js
@@ -1,0 +1,48 @@
+import { getRangeFieldParamFromArithmeticExpression } from '../util';
+
+describe('getRangeFieldParamFromArithmeticExpression', () => {
+  it('processes complex range queries', () => {
+    expect(
+      getRangeFieldParamFromArithmeticExpression({
+        GT: 3,
+        LT: 4,
+        LTE: 5,
+        GTE: 6,
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "gt": 3,
+        "gte": 6,
+        "lt": 4,
+        "lte": 5,
+      }
+    `);
+  });
+  it('processes dates', () => {
+    expect(
+      getRangeFieldParamFromArithmeticExpression({
+        GTE: 'now-1d/d',
+        LT: 'now/d',
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "gte": "now-1d/d",
+        "lt": "now/d",
+      }
+    `);
+  });
+  it('EQ overrides all', () => {
+    expect(
+      getRangeFieldParamFromArithmeticExpression({
+        EQ: 0, // This should override others
+        GT: 3,
+        LTE: 4,
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "gte": 0,
+        "lte": 0,
+      }
+    `);
+  });
+});

--- a/src/graphql/queries/__fixtures__/ListArticles.js
+++ b/src/graphql/queries/__fixtures__/ListArticles.js
@@ -17,11 +17,15 @@ export default {
         status: 'NORMAL',
         createdAt: '2020-02-08T15:11:04.472Z',
         updatedAt: '2020-02-08T15:11:04.472Z',
+        positiveFeedbackCount: 1,
+        negativeFeedbackCount: 0,
       },
       {
         status: 'NORMAL',
         createdAt: '2020-02-05T14:41:19.044Z',
         updatedAt: '2020-02-05T14:41:19.044Z',
+        positiveFeedbackCount: 0,
+        negativeFeedbackCount: 1,
       },
     ],
     articleCategories: [
@@ -48,6 +52,24 @@ export default {
         status: 'NORMAL',
         createdAt: '2020-02-09T15:11:04.472Z',
         updatedAt: '2020-02-09T15:11:04.472Z',
+        positiveFeedbackCount: 0,
+        negativeFeedbackCount: 0,
+      },
+      {
+        // Deleted article replies are not taken into account for createdAt and feedbacks
+        status: 'DELETED',
+        createdAt: '2020-02-15T15:11:04.472Z',
+        updatedAt: '2020-02-16T15:11:04.472Z',
+        positiveFeedbackCount: 3,
+        negativeFeedbackCount: 0,
+      },
+      {
+        // Deleted article replies are not taken into account for createdAt and feedbacks
+        status: 'DELETED',
+        createdAt: '2020-02-04T15:11:04.472Z',
+        updatedAt: '2020-02-04T15:11:04.472Z',
+        positiveFeedbackCount: 3,
+        negativeFeedbackCount: 0,
       },
     ],
     articleCategories: [
@@ -68,19 +90,13 @@ export default {
     createdAt: '2020-02-06T00:00:00.000Z',
     text:
       '人生幾何，離闊如此！況以膠漆之心，置於胡越之身，進不得相合，退不能相忘，牽攣乖隔，各欲白首。',
-    articleReplies: [
-      {
-        status: 'NORMAL',
-        createdAt: '2020-02-05T15:11:04.472Z',
-        updatedAt: '2020-02-05T15:11:04.472Z',
-      },
-    ],
+    articleReplies: [],
   },
   '/articles/doc/listArticleTest4': {
     userId: 'user2',
     appId: 'app1',
     replyRequestCount: 0,
-    normalArticleReplyCount: 0,
+    normalArticleReplyCount: 3,
     updatedAt: 4,
     createdAt: '2020-02-07T00:00:00.000Z',
     text: '我好餓 http://gohome.com',
@@ -98,16 +114,22 @@ export default {
         status: 'NORMAL',
         createdAt: '2020-02-11T15:11:04.472Z',
         updatedAt: '2020-02-11T15:11:04.472Z',
+        positiveFeedbackCount: 10,
+        negativeFeedbackCount: 11,
       },
       {
         status: 'NORMAL',
         createdAt: '2020-02-10T15:11:04.472Z',
         updatedAt: '2020-02-10T15:11:04.472Z',
+        positiveFeedbackCount: 5,
+        negativeFeedbackCount: 7,
       },
       {
         status: 'NORMAL',
         createdAt: '2020-02-09T15:11:04.472Z',
         updatedAt: '2020-02-09T15:11:04.472Z',
+        positiveFeedbackCount: 3,
+        negativeFeedbackCount: 4,
       },
     ],
   },

--- a/src/graphql/queries/__tests__/ListArticles.js
+++ b/src/graphql/queries/__tests__/ListArticles.js
@@ -36,6 +36,7 @@ describe('ListArticles', () => {
             edges {
               node {
                 id
+                updatedAt
               }
             }
             totalCount
@@ -46,7 +47,7 @@ describe('ListArticles', () => {
           }
         }
       `()
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('by updatedAt DESC');
 
     expect(
       await gql`
@@ -55,6 +56,7 @@ describe('ListArticles', () => {
             edges {
               node {
                 id
+                replyRequestCount
               }
             }
             totalCount
@@ -65,7 +67,7 @@ describe('ListArticles', () => {
           }
         }
       `()
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('by replyRequestCount DESC');
 
     expect(
       await gql`
@@ -74,17 +76,15 @@ describe('ListArticles', () => {
             edges {
               node {
                 id
+                articleReplies(status: NORMAL) {
+                  createdAt
+                }
               }
-            }
-            totalCount
-            pageInfo {
-              firstCursor
-              lastCursor
             }
           }
         }
       `()
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('by lastRepliedAt DESC');
   });
 
   const testReplyCount = async expression => {
@@ -97,12 +97,8 @@ describe('ListArticles', () => {
             edges {
               node {
                 id
+                replyCount
               }
-            }
-            totalCount
-            pageInfo {
-              firstCursor
-              lastCursor
             }
           }
         }
@@ -232,7 +228,7 @@ describe('ListArticles', () => {
           }
         }
       `()
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('userId = user1, appId = app1');
 
     // Lists only articles by fromUserOfArticleId
     expect(
@@ -248,7 +244,7 @@ describe('ListArticles', () => {
           }
         }
       `()
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('author of listArticleTest1');
   });
 
   it('filters by time range', async () => {
@@ -261,13 +257,14 @@ describe('ListArticles', () => {
             edges {
               node {
                 id
+                createdAt
               }
             }
             totalCount
           }
         }
       `()
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('later than 2020-02-06');
     expect(
       await gql`
         {
@@ -277,13 +274,14 @@ describe('ListArticles', () => {
             edges {
               node {
                 id
+                createdAt
               }
             }
             totalCount
           }
         }
       `()
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('earlier or equal to 2020-02-06');
     expect(
       await gql`
         {
@@ -298,13 +296,14 @@ describe('ListArticles', () => {
             edges {
               node {
                 id
+                createdAt
               }
             }
             totalCount
           }
         }
       `()
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('between 2020-02-04 and 2020-02-06');
   });
 
   it('filters by replies time range', async () => {
@@ -317,13 +316,16 @@ describe('ListArticles', () => {
             edges {
               node {
                 id
+                articleReplies(status: NORMAL) {
+                  createdAt
+                }
               }
             }
             totalCount
           }
         }
       `()
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('later than 2020-02-06');
     expect(
       await gql`
         {
@@ -333,13 +335,16 @@ describe('ListArticles', () => {
             edges {
               node {
                 id
+                articleReplies(status: NORMAL) {
+                  createdAt
+                }
               }
             }
             totalCount
           }
         }
       `()
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('earlier or equal to 2020-02-06');
     expect(
       await gql`
         {
@@ -354,13 +359,16 @@ describe('ListArticles', () => {
             edges {
               node {
                 id
+                articleReplies(status: NORMAL) {
+                  createdAt
+                }
               }
             }
             totalCount
           }
         }
       `()
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('between 2020-02-04 and 2020-02-06');
   });
 
   it('filters by mixed query', async () => {
@@ -527,6 +535,48 @@ describe('ListArticles', () => {
         }
       `()
     ).toMatchSnapshot();
+  });
+
+  it('filters via article reply feedback count', async () => {
+    expect(
+      await gql`
+        {
+          ListArticles(
+            filter: { hasArticleReplyWithMorePositiveFeedback: true }
+          ) {
+            edges {
+              node {
+                id
+                articleReplies(status: NORMAL) {
+                  positiveFeedbackCount
+                  negativeFeedbackCount
+                }
+              }
+            }
+          }
+        }
+      `()
+    ).toMatchSnapshot('hasArticleReplyWithMorePositiveFeedback = true');
+
+    expect(
+      await gql`
+        {
+          ListArticles(
+            filter: { hasArticleReplyWithMorePositiveFeedback: false }
+          ) {
+            edges {
+              node {
+                id
+                articleReplies(status: NORMAL) {
+                  positiveFeedbackCount
+                  negativeFeedbackCount
+                }
+              }
+            }
+          }
+        }
+      `()
+    ).toMatchSnapshot('hasArticleReplyWithMorePositiveFeedback = false');
   });
 
   afterAll(() => unloadFixtures(fixtures));

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
@@ -116,72 +116,102 @@ Object {
 }
 `;
 
-exports[`ListArticles filters by replies time range 1`] = `
+exports[`ListArticles filters by replies time range: between 2020-02-04 and 2020-02-06 1`] = `
 Object {
   "data": Object {
     "ListArticles": Object {
       "edges": Array [
         Object {
           "node": Object {
+            "articleReplies": Array [
+              Object {
+                "createdAt": "2020-02-08T15:11:04.472Z",
+              },
+              Object {
+                "createdAt": "2020-02-05T14:41:19.044Z",
+              },
+            ],
+            "id": "listArticleTest1",
+          },
+        },
+      ],
+      "totalCount": 1,
+    },
+  },
+}
+`;
+
+exports[`ListArticles filters by replies time range: earlier or equal to 2020-02-06 1`] = `
+Object {
+  "data": Object {
+    "ListArticles": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "articleReplies": Array [
+              Object {
+                "createdAt": "2020-02-08T15:11:04.472Z",
+              },
+              Object {
+                "createdAt": "2020-02-05T14:41:19.044Z",
+              },
+            ],
+            "id": "listArticleTest1",
+          },
+        },
+      ],
+      "totalCount": 1,
+    },
+  },
+}
+`;
+
+exports[`ListArticles filters by replies time range: later than 2020-02-06 1`] = `
+Object {
+  "data": Object {
+    "ListArticles": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "articleReplies": Array [
+              Object {
+                "createdAt": "2020-02-11T15:11:04.472Z",
+              },
+              Object {
+                "createdAt": "2020-02-09T15:11:04.472Z",
+              },
+              Object {
+                "createdAt": "2020-02-10T15:11:04.472Z",
+              },
+            ],
             "id": "listArticleTest4",
           },
         },
         Object {
           "node": Object {
+            "articleReplies": Array [
+              Object {
+                "createdAt": "2020-02-09T15:11:04.472Z",
+              },
+            ],
             "id": "listArticleTest2",
           },
         },
         Object {
           "node": Object {
+            "articleReplies": Array [
+              Object {
+                "createdAt": "2020-02-08T15:11:04.472Z",
+              },
+              Object {
+                "createdAt": "2020-02-05T14:41:19.044Z",
+              },
+            ],
             "id": "listArticleTest1",
           },
         },
       ],
       "totalCount": 3,
-    },
-  },
-}
-`;
-
-exports[`ListArticles filters by replies time range 2`] = `
-Object {
-  "data": Object {
-    "ListArticles": Object {
-      "edges": Array [
-        Object {
-          "node": Object {
-            "id": "listArticleTest3",
-          },
-        },
-        Object {
-          "node": Object {
-            "id": "listArticleTest1",
-          },
-        },
-      ],
-      "totalCount": 2,
-    },
-  },
-}
-`;
-
-exports[`ListArticles filters by replies time range 3`] = `
-Object {
-  "data": Object {
-    "ListArticles": Object {
-      "edges": Array [
-        Object {
-          "node": Object {
-            "id": "listArticleTest3",
-          },
-        },
-        Object {
-          "node": Object {
-            "id": "listArticleTest1",
-          },
-        },
-      ],
-      "totalCount": 2,
     },
   },
 }
@@ -195,14 +225,10 @@ Object {
         Object {
           "node": Object {
             "id": "listArticleTest2",
+            "replyCount": 1,
           },
         },
       ],
-      "pageInfo": Object {
-        "firstCursor": "WyJsaXN0QXJ0aWNsZVRlc3QyIl0=",
-        "lastCursor": "WyJsaXN0QXJ0aWNsZVRlc3QyIl0=",
-      },
-      "totalCount": 1,
     },
   },
 }
@@ -215,15 +241,17 @@ Object {
       "edges": Array [
         Object {
           "node": Object {
+            "id": "listArticleTest4",
+            "replyCount": 3,
+          },
+        },
+        Object {
+          "node": Object {
             "id": "listArticleTest1",
+            "replyCount": 2,
           },
         },
       ],
-      "pageInfo": Object {
-        "firstCursor": "WyJsaXN0QXJ0aWNsZVRlc3QxIl0=",
-        "lastCursor": "WyJsaXN0QXJ0aWNsZVRlc3QxIl0=",
-      },
-      "totalCount": 1,
     },
   },
 }
@@ -236,20 +264,11 @@ Object {
       "edges": Array [
         Object {
           "node": Object {
-            "id": "listArticleTest4",
-          },
-        },
-        Object {
-          "node": Object {
             "id": "listArticleTest3",
+            "replyCount": 0,
           },
         },
       ],
-      "pageInfo": Object {
-        "firstCursor": "WyJsaXN0QXJ0aWNsZVRlc3Q0Il0=",
-        "lastCursor": "WyJsaXN0QXJ0aWNsZVRlc3QzIl0=",
-      },
-      "totalCount": 2,
     },
   },
 }
@@ -272,40 +291,50 @@ Object {
 }
 `;
 
-exports[`ListArticles filters by time range 1`] = `
+exports[`ListArticles filters by time range: between 2020-02-04 and 2020-02-06 1`] = `
 Object {
   "data": Object {
     "ListArticles": Object {
       "edges": Array [
         Object {
           "node": Object {
-            "id": "listArticleTest4",
-          },
-        },
-      ],
-      "totalCount": 1,
-    },
-  },
-}
-`;
-
-exports[`ListArticles filters by time range 2`] = `
-Object {
-  "data": Object {
-    "ListArticles": Object {
-      "edges": Array [
-        Object {
-          "node": Object {
+            "createdAt": "2020-02-06T00:00:00.000Z",
             "id": "listArticleTest3",
           },
         },
         Object {
           "node": Object {
+            "createdAt": "2020-02-05T00:00:00.000Z",
+            "id": "listArticleTest2",
+          },
+        },
+      ],
+      "totalCount": 2,
+    },
+  },
+}
+`;
+
+exports[`ListArticles filters by time range: earlier or equal to 2020-02-06 1`] = `
+Object {
+  "data": Object {
+    "ListArticles": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "createdAt": "2020-02-06T00:00:00.000Z",
+            "id": "listArticleTest3",
+          },
+        },
+        Object {
+          "node": Object {
+            "createdAt": "2020-02-05T00:00:00.000Z",
             "id": "listArticleTest2",
           },
         },
         Object {
           "node": Object {
+            "createdAt": "2020-02-03T00:00:00.000Z",
             "id": "listArticleTest1",
           },
         },
@@ -316,67 +345,136 @@ Object {
 }
 `;
 
-exports[`ListArticles filters by time range 3`] = `
+exports[`ListArticles filters by time range: later than 2020-02-06 1`] = `
 Object {
   "data": Object {
     "ListArticles": Object {
       "edges": Array [
         Object {
           "node": Object {
+            "createdAt": "2020-02-07T00:00:00.000Z",
+            "id": "listArticleTest4",
+          },
+        },
+      ],
+      "totalCount": 1,
+    },
+  },
+}
+`;
+
+exports[`ListArticles filters by userId, appId and fromUserOfArticleId: author of listArticleTest1 1`] = `
+Object {
+  "data": Object {
+    "ListArticles": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "listArticleTest2",
+          },
+        },
+        Object {
+          "node": Object {
+            "id": "listArticleTest1",
+          },
+        },
+      ],
+      "totalCount": 2,
+    },
+  },
+}
+`;
+
+exports[`ListArticles filters by userId, appId and fromUserOfArticleId: userId = user1, appId = app1 1`] = `
+Object {
+  "data": Object {
+    "ListArticles": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "listArticleTest2",
+          },
+        },
+        Object {
+          "node": Object {
+            "id": "listArticleTest1",
+          },
+        },
+      ],
+      "totalCount": 2,
+    },
+  },
+}
+`;
+
+exports[`ListArticles filters via article reply feedback count: hasArticleReplyWithMorePositiveFeedback = false 1`] = `
+Object {
+  "data": Object {
+    "ListArticles": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "articleReplies": Array [
+              Object {
+                "negativeFeedbackCount": 11,
+                "positiveFeedbackCount": 10,
+              },
+              Object {
+                "negativeFeedbackCount": 4,
+                "positiveFeedbackCount": 3,
+              },
+              Object {
+                "negativeFeedbackCount": 7,
+                "positiveFeedbackCount": 5,
+              },
+            ],
+            "id": "listArticleTest4",
+          },
+        },
+        Object {
+          "node": Object {
+            "articleReplies": Array [],
             "id": "listArticleTest3",
           },
         },
         Object {
           "node": Object {
+            "articleReplies": Array [
+              Object {
+                "negativeFeedbackCount": 0,
+                "positiveFeedbackCount": 0,
+              },
+            ],
             "id": "listArticleTest2",
           },
         },
       ],
-      "totalCount": 2,
     },
   },
 }
 `;
 
-exports[`ListArticles filters by userId, appId and fromUserOfArticleId 1`] = `
+exports[`ListArticles filters via article reply feedback count: hasArticleReplyWithMorePositiveFeedback = true 1`] = `
 Object {
   "data": Object {
     "ListArticles": Object {
       "edges": Array [
         Object {
           "node": Object {
-            "id": "listArticleTest2",
-          },
-        },
-        Object {
-          "node": Object {
+            "articleReplies": Array [
+              Object {
+                "negativeFeedbackCount": 0,
+                "positiveFeedbackCount": 1,
+              },
+              Object {
+                "negativeFeedbackCount": 1,
+                "positiveFeedbackCount": 0,
+              },
+            ],
             "id": "listArticleTest1",
           },
         },
       ],
-      "totalCount": 2,
-    },
-  },
-}
-`;
-
-exports[`ListArticles filters by userId, appId and fromUserOfArticleId 2`] = `
-Object {
-  "data": Object {
-    "ListArticles": Object {
-      "edges": Array [
-        Object {
-          "node": Object {
-            "id": "listArticleTest2",
-          },
-        },
-        Object {
-          "node": Object {
-            "id": "listArticleTest1",
-          },
-        },
-      ],
-      "totalCount": 2,
     },
   },
 }
@@ -440,43 +538,63 @@ Object {
 }
 `;
 
-exports[`ListArticles sorts 1`] = `
+exports[`ListArticles sorts: by lastRepliedAt DESC 1`] = `
 Object {
   "data": Object {
     "ListArticles": Object {
       "edges": Array [
         Object {
           "node": Object {
+            "articleReplies": Array [
+              Object {
+                "createdAt": "2020-02-11T15:11:04.472Z",
+              },
+              Object {
+                "createdAt": "2020-02-09T15:11:04.472Z",
+              },
+              Object {
+                "createdAt": "2020-02-10T15:11:04.472Z",
+              },
+            ],
             "id": "listArticleTest4",
           },
         },
         Object {
           "node": Object {
-            "id": "listArticleTest3",
-          },
-        },
-        Object {
-          "node": Object {
+            "articleReplies": Array [
+              Object {
+                "createdAt": "2020-02-09T15:11:04.472Z",
+              },
+            ],
             "id": "listArticleTest2",
           },
         },
         Object {
           "node": Object {
+            "articleReplies": Array [
+              Object {
+                "createdAt": "2020-02-08T15:11:04.472Z",
+              },
+              Object {
+                "createdAt": "2020-02-05T14:41:19.044Z",
+              },
+            ],
             "id": "listArticleTest1",
           },
         },
+        Object {
+          "node": Object {
+            "articleReplies": Array [],
+            "id": "listArticleTest3",
+          },
+        },
       ],
-      "pageInfo": Object {
-        "firstCursor": "WzQsImxpc3RBcnRpY2xlVGVzdDQiXQ==",
-        "lastCursor": "WzEsImxpc3RBcnRpY2xlVGVzdDEiXQ==",
-      },
-      "totalCount": 4,
     },
   },
 }
 `;
 
-exports[`ListArticles sorts 2`] = `
+exports[`ListArticles sorts: by replyRequestCount DESC 1`] = `
 Object {
   "data": Object {
     "ListArticles": Object {
@@ -484,21 +602,25 @@ Object {
         Object {
           "node": Object {
             "id": "listArticleTest1",
+            "replyRequestCount": 2,
           },
         },
         Object {
           "node": Object {
             "id": "listArticleTest2",
+            "replyRequestCount": 1,
           },
         },
         Object {
           "node": Object {
             "id": "listArticleTest4",
+            "replyRequestCount": 0,
           },
         },
         Object {
           "node": Object {
             "id": "listArticleTest3",
+            "replyRequestCount": 0,
           },
         },
       ],
@@ -512,7 +634,7 @@ Object {
 }
 `;
 
-exports[`ListArticles sorts 3`] = `
+exports[`ListArticles sorts: by updatedAt DESC 1`] = `
 Object {
   "data": Object {
     "ListArticles": Object {
@@ -520,27 +642,31 @@ Object {
         Object {
           "node": Object {
             "id": "listArticleTest4",
-          },
-        },
-        Object {
-          "node": Object {
-            "id": "listArticleTest2",
-          },
-        },
-        Object {
-          "node": Object {
-            "id": "listArticleTest1",
+            "updatedAt": "4",
           },
         },
         Object {
           "node": Object {
             "id": "listArticleTest3",
+            "updatedAt": "3",
+          },
+        },
+        Object {
+          "node": Object {
+            "id": "listArticleTest2",
+            "updatedAt": "2",
+          },
+        },
+        Object {
+          "node": Object {
+            "id": "listArticleTest1",
+            "updatedAt": "1",
           },
         },
       ],
       "pageInfo": Object {
-        "firstCursor": "WzE1ODE0MzM4NjQ0NzIsImxpc3RBcnRpY2xlVGVzdDQiXQ==",
-        "lastCursor": "WzE1ODA5MTU0NjQ0NzIsImxpc3RBcnRpY2xlVGVzdDMiXQ==",
+        "firstCursor": "WzQsImxpc3RBcnRpY2xlVGVzdDQiXQ==",
+        "lastCursor": "WzEsImxpc3RBcnRpY2xlVGVzdDEiXQ==",
       },
       "totalCount": 4,
     },

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -42,7 +42,7 @@ export function getRangeFieldParamFromArithmeticExpression(
   arithmeticFilterObj
 ) {
   // EQ overrides all other operators
-  if (arithmeticFilterObj.EQ) {
+  if (typeof arithmeticFilterObj.EQ !== 'undefined') {
     return {
       gte: arithmeticFilterObj.EQ,
       lte: arithmeticFilterObj.EQ,


### PR DESCRIPTION
This PR implements `hasArticleReplyWithMorePositiveFeedback` which:
1. When `true`, gives only the articles with at least 1 article reply whose `#(positive feedback) > #(negative feedback)`
2. When `false`, gives only the articles with no article reply, or all its article replies has `#(positive feedback) <= #(negative feedback)`

I found that `normalArticleReplyCount` in `ListArticles` fixture actually does not match `normalArticleReplyCount`. This PR adjusts `ListArticles` fixtures so that
- For all article fixtures, `normalArticleReplyCount` matches length of `articleReplies` array.
- Preserve some of articles that has no article replies
- Adds some deleted article replies, which should not affect any filter since they are deleted
- Fetches the field that is being sorted / filtered in snapshot, so that the results can be easily verified by reading snapshot files directly
- Removes excessive `pageInfo` and `totalCount` -- we just leaving a few `pageInfo` and `totalCount` in test cases is enough (prove that it works). For most other unit tests the two fields are like noise, so remove them from unit test.