### PR TITLE
Fix range query arithmetic operator bug

### DIFF
--- a/src/graphql/__tests__/util.js
+++ b/src/graphql/__tests__/util.js
@@ -1,0 +1,48 @@
+import { getRangeFieldParamFromArithmeticExpression } from '../util';
+
+describe('getRangeFieldParamFromArithmeticExpression', () => {
+  it('processes complex range queries', () => {
+    expect(
+      getRangeFieldParamFromArithmeticExpression({
+        GT: 3,
+        LT: 4,
+        LTE: 5,
+        GTE: 6,
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "gt": 3,
+        "gte": 6,
+        "lt": 4,
+        "lte": 5,
+      }
+    `);
+  });
+  it('processes dates', () => {
+    expect(
+      getRangeFieldParamFromArithmeticExpression({
+        GTE: 'now-1d/d',
+        LT: 'now/d',
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "gte": "now-1d/d",
+        "lt": "now/d",
+      }
+    `);
+  });
+  it('EQ overrides all', () => {
+    expect(
+      getRangeFieldParamFromArithmeticExpression({
+        EQ: 0, // This should override others
+        GT: 3,
+        LTE: 4,
+      })
+    ).toMatchInlineSnapshot(`
+      Object {
+        "gte": 0,
+        "lte": 0,
+      }
+    `);
+  });
+});

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -42,7 +42,7 @@ export function getRangeFieldParamFromArithmeticExpression(
   arithmeticFilterObj
 ) {
   // EQ overrides all other operators
-  if (arithmeticFilterObj.EQ) {
+  if (typeof arithmeticFilterObj.EQ !== 'undefined') {
     return {
       gte: arithmeticFilterObj.EQ,
       lte: arithmeticFilterObj.EQ,


### PR DESCRIPTION
Pushing #161 to staging yields the following error:

![image](https://user-images.githubusercontent.com/108608/79492409-8e391280-8052-11ea-981b-0de78612f135.png)

The query variable sent by UI is:

```
{filter: {replyRequestCount: {GT: 1}, replyCount: {EQ: 0}}, orderBy: [{lastRequestedAt: "DESC"}]}
```

Note that `EQ: 0` makes `EQ` falsy and `getRangeFieldParamFromArithmeticExpression` does not properly handle the case, generating `replyCount:  {eq: 0}` as a elasticsearch range query

This PR fixes `getRangeFieldParamFromArithmeticExpression` and adds unit test addressing `getRangeFieldParamFromArithmeticExpression`.

Notice that this does not overlap with existing API test, since the API test connects to DB, and the unit test included in this PR tests boundary conditions that is too trivial to prepare DB fixtures for an API test.