### PR TITLE
requestedForReply should return null when not logged in

### DIFF
--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -14,7 +14,6 @@ import {
   createFilterType,
   createSortType,
   createConnectionType,
-  assertUser,
   filterArticleRepliesByStatus,
   filterArticleCategoriesByStatus,
 } from 'graphql/util';
@@ -138,9 +137,9 @@ const Article = new GraphQLObjectType({
     requestedForReply: {
       type: GraphQLBoolean,
       description:
-        'If the current user has requested for reply for this article',
+        'If the current user has requested for reply for this article. Null if not logged in.',
       resolve: async ({ id }, args, { userId, appId, loaders }) => {
-        assertUser({ userId, appId });
+        if (!userId || !appId) return null;
 
         const userReplyRequests = await loaders.searchResultLoader.load({
           index: 'replyrequests',

--- a/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
+++ b/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
@@ -219,6 +219,18 @@ describe('GetReplyAndGetArticle', () => {
         `()
       ).toMatchSnapshot();
     });
+
+    it('authenticated fields returns null for non-logged users', async () => {
+      expect(
+        await gql`
+          {
+            GetArticle(id: "foo") {
+              requestedForReply
+            }
+          }
+        `({}, { appId: 'LINE' })
+      ).toMatchSnapshot();
+    });
   });
 
   describe('GetReply', () => {

--- a/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`GetReplyAndGetArticle GetArticle authenticated fields returns null for non-logged users 1`] = `
+Object {
+  "data": Object {
+    "GetArticle": Object {
+      "requestedForReply": null,
+    },
+  },
+}
+`;
+
 exports[`GetReplyAndGetArticle GetArticle feedbacks should work: feedback loading test 1`] = `
 Object {
   "data": Object {


### PR DESCRIPTION
Currently, `requestedForReply` of `Article` object type would throw error if the user is not logged-in. However, other fields that requires authentication (such as [`ownVote`](https://github.com/cofacts/rumors-api/blob/master/src/graphql/models/ArticleReply.js#L68-L89), [`canUpdateStatus`](https://github.com/cofacts/rumors-api/blob/master/src/graphql/models/ArticleReply.js#L42-L51)) just returns `null` if the user is not logged in.

`assertUser()` is meant for mutation resolvers and ordinary object type resolvers should avoid using `assertUser()`.

Related discussion: 
- https://g0v-tw.slack.com/archives/C2PPMRQGP/p1588665581350300
- https://g0v-slack-archive.g0v.ronny.tw/index/channel/C2PPMRQGP#ts-1588665581.350300