### PR TITLE
[Refactor] remove duplicated input object types

### DIFF
--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -8,7 +8,7 @@ import {
 
 import {
   pagingArgs,
-  getArithmeticExpressionType,
+  intRangeInput,
   getSortArgs,
   getRangeFieldParamFromArithmeticExpression,
   createFilterType,
@@ -164,9 +164,7 @@ const Article = new GraphQLObjectType({
       args: {
         filter: {
           type: createFilterType('RelatedArticleFilter', {
-            replyCount: {
-              type: getArithmeticExpressionType('ReplyCountExpr', GraphQLInt),
-            },
+            replyCount: { type: intRangeInput },
           }),
         },
         orderBy: {

--- a/src/graphql/mutations/__tests__/CreateReply.js
+++ b/src/graphql/mutations/__tests__/CreateReply.js
@@ -83,6 +83,9 @@ describe('CreateReply', () => {
 
     // Cleanup
     await client.delete({ index: 'replies', type: 'doc', id: replyId });
+
+    // refresh must be invoked before deleteByQuery, or the query may find nothing and delete nothing
+    await client.indices.refresh({ index: 'urls' });
     await client.deleteByQuery({
       index: 'urls',
       type: 'doc',

--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -1,5 +1,4 @@
 import {
-  GraphQLInt,
   GraphQLString,
   GraphQLInputObjectType,
   GraphQLList,
@@ -12,7 +11,8 @@ import {
   createSortType,
   getSortArgs,
   pagingArgs,
-  getArithmeticExpressionType,
+  intRangeInput,
+  timeRangeInput,
   getRangeFieldParamFromArithmeticExpression,
 } from 'graphql/util';
 import scrapUrls from 'util/scrapUrls';
@@ -24,18 +24,12 @@ export default {
     filter: {
       type: createFilterType('ListArticleFilter', {
         replyCount: {
-          type: getArithmeticExpressionType(
-            'ListArticleReplyCountExpr',
-            GraphQLInt
-          ),
+          type: intRangeInput,
           description:
             'List only the articles whose number of replies matches the criteria.',
         },
         categoryCount: {
-          type: getArithmeticExpressionType(
-            'ListArticleCategoryCountExpr',
-            GraphQLInt
-          ),
+          type: intRangeInput,
           description:
             'List only the articles whose number of categories match the criteria.',
         },
@@ -58,32 +52,19 @@ export default {
           description: 'List all articles related to a given string.',
         },
         replyRequestCount: {
-          type: getArithmeticExpressionType(
-            'ListArticleReplyRequestCountExpr',
-            GraphQLInt
-          ),
+          type: intRangeInput,
           description:
             'List only the articles whose number of replies matches the criteria.',
         },
         createdAt: {
-          type: getArithmeticExpressionType(
-            'ListArticleCreatedAtExpr',
-            GraphQLString
-          ),
-          description: `
-            List only the articles that were created between the specific time range.
-            The time range value is in elasticsearch date format (https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html)
-          `,
+          type: timeRangeInput,
+          description:
+            'List only the articles that were created between the specific time range.',
         },
         repliedAt: {
-          type: getArithmeticExpressionType(
-            'ListArticleRepliedAtExpr',
-            GraphQLString
-          ),
-          description: `
-            List only the articles that were replied between the specific time range.
-            The time range value is in elasticsearch date format (https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html)
-          `,
+          type: timeRangeInput,
+          description:
+            'List only the articles that were replied between the specific time range.',
         },
         appId: {
           type: GraphQLString,

--- a/src/graphql/queries/ListReplies.js
+++ b/src/graphql/queries/ListReplies.js
@@ -7,7 +7,7 @@ import {
   createConnectionType,
   getSortArgs,
   pagingArgs,
-  getArithmeticExpressionType,
+  timeRangeInput,
   getRangeFieldParamFromArithmeticExpression,
 } from 'graphql/util';
 import scrapUrls from 'util/scrapUrls';
@@ -37,14 +37,9 @@ export default {
           description: 'List the replies of certain types',
         },
         createdAt: {
-          type: getArithmeticExpressionType(
-            'ListRepliesCreatedAtExpr',
-            GraphQLString
-          ),
-          description: `
-            List only the replies that were created between the specific time range.
-            The time range value is in elasticsearch date format (https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html)
-          `,
+          type: timeRangeInput,
+          description:
+            'List only the replies that were created between the specific time range.',
         },
       }),
     },

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
@@ -18,7 +18,7 @@ Object {
 exports[`ListArticles filters by invalid operator 1`] = `
 Object {
   "errors": Array [
-    [GraphQLError: Field "INVALID" is not defined by type "ListArticleReplyCountExpr".],
+    [GraphQLError: Field "INVALID" is not defined by type "RangeInput".],
   ],
 }
 `;

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -18,11 +18,13 @@ import client from 'util/client';
 /**
  * @param {string} typeName
  * @param {GraphQLScalarType} argType
+ * @param {string} description
  * @returns {GraphQLInputObjectType}
  */
-export function getArithmeticExpressionType(typeName, argType) {
+function getArithmeticExpressionType(typeName, argType, description) {
   return new GraphQLInputObjectType({
     name: typeName,
+    description,
     fields: {
       LT: { type: argType },
       LTE: { type: argType },
@@ -32,6 +34,18 @@ export function getArithmeticExpressionType(typeName, argType) {
     },
   });
 }
+
+export const timeRangeInput = getArithmeticExpressionType(
+  'TimeRangeInput',
+  GraphQLString,
+  'List only the entries that were created between the specific time range. ' +
+    'The time range value is in elasticsearch date format (https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-date-format.html)'
+);
+export const intRangeInput = getArithmeticExpressionType(
+  'RangeInput',
+  GraphQLInt,
+  'List only the entries whose field match the criteria.'
+);
 
 /**
  * @param {object} arithmeticFilterObj - {LT, LTE, GT, GTE, EQ}, the structure returned by getArithmeticExpressionType


### PR DESCRIPTION
Previously, every arithmetic input (with `{LT, GT, ...}`) has its own input object type, but they are almost the same -- there are only 2 types of such input throughout `rumors-api`, one is for integers, another for date strings.

This PR replaces these `getArithmeticExpressionType` calls with 2 input object type instance to simplify the schema. Behavior of rumors-api should not be affected at all.