### PR TITLE
Add "types" filter for ListReplies

### DIFF
--- a/src/graphql/queries/ListReplies.js
+++ b/src/graphql/queries/ListReplies.js
@@ -1,4 +1,4 @@
-import { GraphQLBoolean } from 'graphql';
+import { GraphQLBoolean, GraphQLList } from 'graphql';
 import client from 'util/client';
 
 import {
@@ -29,6 +29,12 @@ export default {
         },
         type: {
           type: ReplyTypeEnum,
+          // FIXME: No deprecationReason for input object types yet
+          // https://github.com/graphql/graphql-spec/pull/525
+          description: '[Deprecated] use types instead.',
+        },
+        types: {
+          type: new GraphQLList(ReplyTypeEnum),
           description: 'List the replies of certain types',
         },
         createdAt: {
@@ -126,6 +132,14 @@ export default {
       filterQueries.push({
         term: {
           type: filter.type,
+        },
+      });
+    }
+
+    if (filter.types && filter.types.length > 0) {
+      filterQueries.push({
+        terms: {
+          type: filter.types,
         },
       });
     }

--- a/src/graphql/queries/__tests__/ListReplies.js
+++ b/src/graphql/queries/__tests__/ListReplies.js
@@ -59,6 +59,7 @@ describe('ListReplies', () => {
             edges {
               node {
                 id
+                text
               }
             }
             totalCount
@@ -69,7 +70,7 @@ describe('ListReplies', () => {
           }
         }
       `()
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('moreLikeThis = foo');
 
     expect(
       await gql`
@@ -78,6 +79,9 @@ describe('ListReplies', () => {
             edges {
               node {
                 id
+                user {
+                  id
+                }
               }
             }
             totalCount
@@ -94,8 +98,9 @@ describe('ListReplies', () => {
           appId: 'test',
         }
       )
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('selfOnly (userId = foo)');
 
+    // Deprecated
     expect(
       await gql`
         {
@@ -103,6 +108,7 @@ describe('ListReplies', () => {
             edges {
               node {
                 id
+                type
               }
             }
             totalCount
@@ -113,7 +119,23 @@ describe('ListReplies', () => {
           }
         }
       `()
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('type = RUMOR');
+
+    expect(
+      await gql`
+        {
+          ListReplies(filter: { types: [RUMOR, NOT_RUMOR] }) {
+            edges {
+              node {
+                id
+                type
+              }
+            }
+            totalCount
+          }
+        }
+      `()
+    ).toMatchSnapshot('types = RUMOR, NOT_RUMOR');
   });
 
   it('filters by moreLikeThis and given text, find replies containing hyperlinks with the said text', async () => {
@@ -167,13 +189,14 @@ describe('ListReplies', () => {
             edges {
               node {
                 id
+                createdAt
               }
             }
             totalCount
           }
         }
       `()
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('createdAt > 2020/2/6');
     expect(
       await gql`
         {
@@ -183,13 +206,14 @@ describe('ListReplies', () => {
             edges {
               node {
                 id
+                createdAt
               }
             }
             totalCount
           }
         }
       `()
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('createdAt <= 2020/2/6');
     expect(
       await gql`
         {
@@ -204,13 +228,14 @@ describe('ListReplies', () => {
             edges {
               node {
                 id
+                createdAt
               }
             }
             totalCount
           }
         }
       `()
-    ).toMatchSnapshot();
+    ).toMatchSnapshot('2020/2/4 <= createdAt <= 2020/2/6');
   });
 
   it('filters by mixed query', async () => {

--- a/src/graphql/queries/__tests__/__snapshots__/ListReplies.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListReplies.js.snap
@@ -1,73 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ListReplies filters 1`] = `
-Object {
-  "data": Object {
-    "ListReplies": Object {
-      "edges": Array [
-        Object {
-          "node": Object {
-            "id": "moreLikeThis2",
-          },
-        },
-        Object {
-          "node": Object {
-            "id": "moreLikeThis1",
-          },
-        },
-      ],
-      "pageInfo": Object {
-        "firstCursor": "WyJtb3JlTGlrZVRoaXMyIl0=",
-        "lastCursor": "WyJtb3JlTGlrZVRoaXMxIl0=",
-      },
-      "totalCount": 2,
-    },
-  },
-}
-`;
-
-exports[`ListReplies filters 2`] = `
-Object {
-  "data": Object {
-    "ListReplies": Object {
-      "edges": Array [
-        Object {
-          "node": Object {
-            "id": "userFoo",
-          },
-        },
-      ],
-      "pageInfo": Object {
-        "firstCursor": "WyJ1c2VyRm9vIl0=",
-        "lastCursor": "WyJ1c2VyRm9vIl0=",
-      },
-      "totalCount": 1,
-    },
-  },
-}
-`;
-
-exports[`ListReplies filters 3`] = `
-Object {
-  "data": Object {
-    "ListReplies": Object {
-      "edges": Array [
-        Object {
-          "node": Object {
-            "id": "rumor",
-          },
-        },
-      ],
-      "pageInfo": Object {
-        "firstCursor": "WyJydW1vciJd",
-        "lastCursor": "WyJydW1vciJd",
-      },
-      "totalCount": 1,
-    },
-  },
-}
-`;
-
 exports[`ListReplies filters by mixed query 1`] = `
 Object {
   "data": Object {
@@ -127,13 +59,86 @@ Object {
 }
 `;
 
-exports[`ListReplies filters by time range 1`] = `
+exports[`ListReplies filters by time range: 2020/2/4 <= createdAt <= 2020/2/6 1`] = `
 Object {
   "data": Object {
     "ListReplies": Object {
       "edges": Array [
         Object {
           "node": Object {
+            "createdAt": "2020-02-04T00:00:00.000Z",
+            "id": "rumor",
+          },
+        },
+        Object {
+          "node": Object {
+            "createdAt": "2020-02-04T00:00:00.000Z",
+            "id": "referenceUrl",
+          },
+        },
+        Object {
+          "node": Object {
+            "createdAt": "2020-02-05T00:00:00.000Z",
+            "id": "moreLikeThis2",
+          },
+        },
+        Object {
+          "node": Object {
+            "createdAt": "2020-02-06T00:00:00.000Z",
+            "id": "moreLikeThis1",
+          },
+        },
+      ],
+      "totalCount": 4,
+    },
+  },
+}
+`;
+
+exports[`ListReplies filters by time range: createdAt <= 2020/2/6 1`] = `
+Object {
+  "data": Object {
+    "ListReplies": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "createdAt": "2020-02-04T00:00:00.000Z",
+            "id": "rumor",
+          },
+        },
+        Object {
+          "node": Object {
+            "createdAt": "2020-02-04T00:00:00.000Z",
+            "id": "referenceUrl",
+          },
+        },
+        Object {
+          "node": Object {
+            "createdAt": "2020-02-05T00:00:00.000Z",
+            "id": "moreLikeThis2",
+          },
+        },
+        Object {
+          "node": Object {
+            "createdAt": "2020-02-06T00:00:00.000Z",
+            "id": "moreLikeThis1",
+          },
+        },
+      ],
+      "totalCount": 4,
+    },
+  },
+}
+`;
+
+exports[`ListReplies filters by time range: createdAt > 2020/2/6 1`] = `
+Object {
+  "data": Object {
+    "ListReplies": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "createdAt": "2020-02-07T00:00:00.000Z",
             "id": "userFoo",
           },
         },
@@ -144,39 +149,59 @@ Object {
 }
 `;
 
-exports[`ListReplies filters by time range 2`] = `
+exports[`ListReplies filters: moreLikeThis = foo 1`] = `
 Object {
   "data": Object {
     "ListReplies": Object {
       "edges": Array [
         Object {
           "node": Object {
-            "id": "rumor",
-          },
-        },
-        Object {
-          "node": Object {
-            "id": "referenceUrl",
-          },
-        },
-        Object {
-          "node": Object {
             "id": "moreLikeThis2",
+            "text": "foo foo foo",
           },
         },
         Object {
           "node": Object {
             "id": "moreLikeThis1",
+            "text": "foo foo",
           },
         },
       ],
-      "totalCount": 4,
+      "pageInfo": Object {
+        "firstCursor": "WyJtb3JlTGlrZVRoaXMyIl0=",
+        "lastCursor": "WyJtb3JlTGlrZVRoaXMxIl0=",
+      },
+      "totalCount": 2,
     },
   },
 }
 `;
 
-exports[`ListReplies filters by time range 3`] = `
+exports[`ListReplies filters: selfOnly (userId = foo) 1`] = `
+Object {
+  "data": Object {
+    "ListReplies": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "userFoo",
+            "user": Object {
+              "id": "foo",
+            },
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "firstCursor": "WyJ1c2VyRm9vIl0=",
+        "lastCursor": "WyJ1c2VyRm9vIl0=",
+      },
+      "totalCount": 1,
+    },
+  },
+}
+`;
+
+exports[`ListReplies filters: type = RUMOR 1`] = `
 Object {
   "data": Object {
     "ListReplies": Object {
@@ -184,25 +209,39 @@ Object {
         Object {
           "node": Object {
             "id": "rumor",
+            "type": "RUMOR",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "firstCursor": "WyJydW1vciJd",
+        "lastCursor": "WyJydW1vciJd",
+      },
+      "totalCount": 1,
+    },
+  },
+}
+`;
+
+exports[`ListReplies filters: types = RUMOR, NOT_RUMOR 1`] = `
+Object {
+  "data": Object {
+    "ListReplies": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "rumor",
+            "type": "RUMOR",
           },
         },
         Object {
           "node": Object {
             "id": "referenceUrl",
-          },
-        },
-        Object {
-          "node": Object {
-            "id": "moreLikeThis2",
-          },
-        },
-        Object {
-          "node": Object {
-            "id": "moreLikeThis1",
+            "type": "NOT_RUMOR",
           },
         },
       ],
-      "totalCount": 4,
+      "totalCount": 2,
     },
   },
 }


### PR DESCRIPTION
[Reply page mockup](https://www.figma.com/file/zpD45j8nqDB2XfA6m2QskO/Cofacts-website?node-id=299%3A403) requires a multi-select reply type filter for `ListReplies`.

This PR:
- implements `ListReplies`'s `types` filter.
- add snapshot names & fields under test to test cases that has multiple snapshot files so that it's easier to do code review.
