### PR TITLE
Multiple ArticleReplyFeedback filters should narrow down selection

### DIFF
--- a/src/graphql/queries/ListArticleReplyFeedbacks.js
+++ b/src/graphql/queries/ListArticleReplyFeedbacks.js
@@ -75,7 +75,7 @@ export default {
 
     ['userId', 'appId', 'articleId', 'replyId'].forEach(field => {
       if (!filter[field]) return;
-      shouldQueries.push({ term: { [field]: filter[field] } });
+      filterQueries.push({ term: { [field]: filter[field] } });
     });
 
     if (filter.moreLikeThis) {
@@ -92,7 +92,7 @@ export default {
     }
 
     if (filter.vote) {
-      shouldQueries.push({
+      filterQueries.push({
         terms: {
           score: filter.vote,
         },
@@ -101,7 +101,7 @@ export default {
 
     ['createdAt', 'updatedAt'].forEach(field => {
       if (!filter[field]) return;
-      shouldQueries.push({
+      filterQueries.push({
         range: {
           [field]: getRangeFieldParamFromArithmeticExpression(filter[field]),
         },

--- a/src/graphql/queries/__tests__/ListArticleReplyFeedbacks.js
+++ b/src/graphql/queries/__tests__/ListArticleReplyFeedbacks.js
@@ -207,4 +207,54 @@ describe('ListArticleReplyFeedbacks', () => {
       `()
     ).toMatchSnapshot('updated after 2020-04-15');
   });
+
+  it('filters by date, vote and userId alltogether', async () => {
+    expect(
+      await gql`
+        {
+          ListArticleReplyFeedbacks(
+            filter: {
+              updatedAt: { GT: "2020-04-15T00:00:00Z" }
+              vote: UPVOTE
+              userId: "user2"
+            }
+          ) {
+            edges {
+              node {
+                id
+                updatedAt
+                vote
+                user {
+                  id
+                }
+              }
+            }
+            totalCount
+          }
+        }
+      `()
+    ).toMatchSnapshot('updated by user2 after 2020/4/15, UPVOTE');
+
+    // Empty
+    expect(
+      await gql`
+        {
+          ListArticleReplyFeedbacks(
+            filter: {
+              updatedAt: { GT: "2020-04-15T00:00:00Z" }
+              vote: UPVOTE
+              userId: "user1"
+            }
+          ) {
+            edges {
+              node {
+                id
+              }
+            }
+            totalCount
+          }
+        }
+      `()
+    ).toMatchSnapshot('should be empty');
+  });
 });

--- a/src/graphql/queries/__tests__/ListArticleReplyFeedbacks.js
+++ b/src/graphql/queries/__tests__/ListArticleReplyFeedbacks.js
@@ -224,9 +224,7 @@ describe('ListArticleReplyFeedbacks', () => {
                 id
                 updatedAt
                 vote
-                user {
-                  id
-                }
+                userId
               }
             }
             totalCount

--- a/src/graphql/queries/__tests__/ListArticleReplyFeedbacks.js
+++ b/src/graphql/queries/__tests__/ListArticleReplyFeedbacks.js
@@ -232,7 +232,7 @@ describe('ListArticleReplyFeedbacks', () => {
             totalCount
           }
         }
-      `()
+      `({}, { appId: 'WEBSITE' })
     ).toMatchSnapshot('updated by user2 after 2020/4/15, UPVOTE');
 
     // Empty

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticleReplyFeedbacks.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticleReplyFeedbacks.js.snap
@@ -128,7 +128,7 @@ Object {
           "node": Object {
             "id": "f3",
             "updatedAt": "2020-06-06T00:00:00.000Z",
-            "user": null,
+            "userId": "user2",
             "vote": "UPVOTE",
           },
         },

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticleReplyFeedbacks.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticleReplyFeedbacks.js.snap
@@ -112,24 +112,8 @@ exports[`ListArticleReplyFeedbacks filters by date, vote and userId alltogether:
 Object {
   "data": Object {
     "ListArticleReplyFeedbacks": Object {
-      "edges": Array [
-        Object {
-          "node": Object {
-            "id": "f3",
-          },
-        },
-        Object {
-          "node": Object {
-            "id": "f2",
-          },
-        },
-        Object {
-          "node": Object {
-            "id": "f1",
-          },
-        },
-      ],
-      "totalCount": 3,
+      "edges": Array [],
+      "totalCount": 0,
     },
   },
 }
@@ -148,24 +132,8 @@ Object {
             "vote": "UPVOTE",
           },
         },
-        Object {
-          "node": Object {
-            "id": "f2",
-            "updatedAt": "2020-05-06T00:00:00.000Z",
-            "user": null,
-            "vote": "DOWNVOTE",
-          },
-        },
-        Object {
-          "node": Object {
-            "id": "f1",
-            "updatedAt": "2020-04-06T00:00:00.000Z",
-            "user": null,
-            "vote": "UPVOTE",
-          },
-        },
       ],
-      "totalCount": 3,
+      "totalCount": 1,
     },
   },
 }

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticleReplyFeedbacks.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticleReplyFeedbacks.js.snap
@@ -108,6 +108,69 @@ Object {
 }
 `;
 
+exports[`ListArticleReplyFeedbacks filters by date, vote and userId alltogether: should be empty 1`] = `
+Object {
+  "data": Object {
+    "ListArticleReplyFeedbacks": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "f3",
+          },
+        },
+        Object {
+          "node": Object {
+            "id": "f2",
+          },
+        },
+        Object {
+          "node": Object {
+            "id": "f1",
+          },
+        },
+      ],
+      "totalCount": 3,
+    },
+  },
+}
+`;
+
+exports[`ListArticleReplyFeedbacks filters by date, vote and userId alltogether: updated by user2 after 2020/4/15, UPVOTE 1`] = `
+Object {
+  "data": Object {
+    "ListArticleReplyFeedbacks": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "f3",
+            "updatedAt": "2020-06-06T00:00:00.000Z",
+            "user": null,
+            "vote": "UPVOTE",
+          },
+        },
+        Object {
+          "node": Object {
+            "id": "f2",
+            "updatedAt": "2020-05-06T00:00:00.000Z",
+            "user": null,
+            "vote": "DOWNVOTE",
+          },
+        },
+        Object {
+          "node": Object {
+            "id": "f1",
+            "updatedAt": "2020-04-06T00:00:00.000Z",
+            "user": null,
+            "vote": "UPVOTE",
+          },
+        },
+      ],
+      "totalCount": 3,
+    },
+  },
+}
+`;
+
 exports[`ListArticleReplyFeedbacks filters by dates: created before 2020-03-15 1`] = `
 Object {
   "data": Object {


### PR DESCRIPTION
Currently if we specify multiple filters to `ArticleReplyFeedback`, the search result will be the union of all filters:

1.
  - Filter: `{createdAt: {GT: "2020-05-29T00:00:00Z"}}`
  - Result `totalCount`: 26
2.
  - Filter: `{createdAt: {GT: "2020-05-29T00:00:00Z"}, vote: UPVOTE}`
  - Result`totalCount`: 145358

This PR changes the behavior to intersection so that the filter is more useful.

## Root cause
Originally the filters are attached to `shouldQueries`. However, we allow elasticsearch to include documents that matches only 1 should cause. `shouldQueries` should be only used in queries that involves relevance scoring, such as `more_like_this`.

## Proposed fix
Use `filterQueries` instead. All filters must match for elasticsearch to include a document.