### PR TITLE
Implement articleRepliesFrom filter for ListArticles

### DIFF
--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -1,4 +1,10 @@
-import { GraphQLString, GraphQLList, GraphQLBoolean } from 'graphql';
+import {
+  GraphQLString,
+  GraphQLList,
+  GraphQLBoolean,
+  GraphQLInputObjectType,
+  GraphQLNonNull,
+} from 'graphql';
 import client from 'util/client';
 
 import {
@@ -67,6 +73,26 @@ export default {
             Specify an articleId here to show only articles from the sender of that specified article.
             When specified, it overrides the settings of appId and userId.
           `,
+        },
+        articleRepliesFrom: {
+          description:
+            'Show only articles with(out) article replies created by specified user',
+          type: new GraphQLInputObjectType({
+            name: 'UserAndExistInput',
+            fields: {
+              userId: {
+                type: new GraphQLNonNull(GraphQLString),
+              },
+              exists: {
+                type: GraphQLBoolean,
+                defaultValue: true,
+                description: `
+                  When true (or not specified), return only entries with the specified user's involvement.
+                  When false, return only entries that the specified user did not involve.
+                `,
+              },
+            },
+          }),
         },
         hasArticleReplyWithMorePositiveFeedback: {
           type: GraphQLBoolean,
@@ -273,7 +299,7 @@ export default {
     }
 
     if (filter.categoryIds && filter.categoryIds.length) {
-      shouldQueries.push({
+      filterQueries.push({
         bool: {
           should: filter.categoryIds.map(categoryId => ({
             nested: {
@@ -291,7 +317,7 @@ export default {
 
     if (typeof filter.hasArticleReplyWithMorePositiveFeedback === 'boolean') {
       (filter.hasArticleReplyWithMorePositiveFeedback
-        ? shouldQueries
+        ? filterQueries
         : mustNotQueries
       ).push({
         nested: {
@@ -311,6 +337,33 @@ export default {
                         "doc['articleReplies.positiveFeedbackCount'].value > doc['articleReplies.negativeFeedbackCount'].value",
                       lang: 'painless',
                     },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    }
+
+    if (filter.articleRepliesFrom) {
+      (filter.articleRepliesFrom.exists === false
+        ? mustNotQueries
+        : filterQueries
+      ).push({
+        nested: {
+          path: 'articleReplies',
+          query: {
+            bool: {
+              must: [
+                {
+                  term: {
+                    'articleReplies.status': 'NORMAL',
+                  },
+                },
+                {
+                  term: {
+                    'articleReplies.userId': filter.articleRepliesFrom.userId,
                   },
                 },
               ],

--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -55,13 +55,11 @@ export default {
         },
         appId: {
           type: GraphQLString,
-          description:
-            'Use with userId to show only articles from a specific user.',
+          description: 'Show only articles from a specific user.',
         },
         userId: {
           type: GraphQLString,
-          description:
-            'Use with appId to show only articles from a specific user.',
+          description: 'Show only articles from a specific user.',
         },
         fromUserOfArticleId: {
           type: GraphQLString,
@@ -152,14 +150,10 @@ export default {
       filter.appId = specifiedArticle.appId;
     }
 
-    if (filter.appId && filter.userId) {
-      filterQueries.push(
-        { term: { appId: filter.appId } },
-        { term: { userId: filter.userId } }
-      );
-    } else if (filter.appId || filter.userId) {
-      throw new Error('Both appId and userId must be specified at once');
-    }
+    ['userId', 'appId'].forEach(field => {
+      if (!filter[field]) return;
+      filterQueries.push({ term: { [field]: filter[field] } });
+    });
 
     if (filter.moreLikeThis) {
       const scrapResults = (await scrapUrls(filter.moreLikeThis.like, {

--- a/src/graphql/queries/ListReplies.js
+++ b/src/graphql/queries/ListReplies.js
@@ -37,7 +37,7 @@ export default {
           type: ReplyTypeEnum,
           // FIXME: No deprecationReason for input object types yet
           // https://github.com/graphql/graphql-spec/pull/525
-          description: '[Deprecated] use types instead',
+          description: '[Deprecated] use types instead.',
         },
         types: {
           type: new GraphQLList(ReplyTypeEnum),

--- a/src/graphql/queries/ListReplies.js
+++ b/src/graphql/queries/ListReplies.js
@@ -1,4 +1,4 @@
-import { GraphQLBoolean, GraphQLList } from 'graphql';
+import { GraphQLBoolean, GraphQLList, GraphQLString } from 'graphql';
 import client from 'util/client';
 
 import {
@@ -20,6 +20,12 @@ export default {
   args: {
     filter: {
       type: createFilterType('ListReplyFilter', {
+        userId: {
+          type: GraphQLString,
+        },
+        appId: {
+          type: GraphQLString,
+        },
         moreLikeThis: {
           type: moreLikeThisInput,
         },
@@ -31,7 +37,7 @@ export default {
           type: ReplyTypeEnum,
           // FIXME: No deprecationReason for input object types yet
           // https://github.com/graphql/graphql-spec/pull/525
-          description: '[Deprecated] use types instead.',
+          description: '[Deprecated] use types instead',
         },
         types: {
           type: new GraphQLList(ReplyTypeEnum),
@@ -128,13 +134,10 @@ export default {
       }
     }
 
-    if (filter.type) {
-      filterQueries.push({
-        term: {
-          type: filter.type,
-        },
-      });
-    }
+    ['userId', 'appId', 'type' /* deprecated */].forEach(field => {
+      if (!filter[field]) return;
+      filterQueries.push({ term: { [field]: filter[field] } });
+    });
 
     if (filter.types && filter.types.length > 0) {
       filterQueries.push({

--- a/src/graphql/queries/__fixtures__/ListArticles.js
+++ b/src/graphql/queries/__fixtures__/ListArticles.js
@@ -17,6 +17,8 @@ export default {
         status: 'NORMAL',
         createdAt: '2020-02-08T15:11:04.472Z',
         updatedAt: '2020-02-08T15:11:04.472Z',
+        userId: 'user1',
+        appId: 'WEBSITE',
         positiveFeedbackCount: 1,
         negativeFeedbackCount: 0,
       },
@@ -60,6 +62,8 @@ export default {
         status: 'DELETED',
         createdAt: '2020-02-15T15:11:04.472Z',
         updatedAt: '2020-02-16T15:11:04.472Z',
+        userId: 'user1',
+        appId: 'WEBSITE',
         positiveFeedbackCount: 3,
         negativeFeedbackCount: 0,
       },
@@ -158,5 +162,8 @@ export default {
     summary:
       '臣亮言：先帝創業未半，而中道崩殂。今天下三分，益州 疲弊，此誠危急存亡之秋也。',
     topImageUrl: 'http://出師表.com/image.jpg',
+  },
+  '/users/doc/user1': {
+    name: 'user1',
   },
 };

--- a/src/graphql/queries/__tests__/ListArticles.js
+++ b/src/graphql/queries/__tests__/ListArticles.js
@@ -398,20 +398,6 @@ describe('ListArticles', () => {
   });
 
   it('throws error when author filter is not set correctly', async () => {
-    const { errors: noUserIdError } = await gql`
-      {
-        ListArticles(filter: { appId: "specified-but-no-user-id" }) {
-          edges {
-            node {
-              id
-            }
-          }
-          totalCount
-        }
-      }
-    `();
-    expect(noUserIdError).toMatchSnapshot();
-
     const { errors: notExistError } = await gql`
       {
         ListArticles(filter: { fromUserOfArticleId: "not-exist" }) {

--- a/src/graphql/queries/__tests__/ListArticles.js
+++ b/src/graphql/queries/__tests__/ListArticles.js
@@ -565,5 +565,47 @@ describe('ListArticles', () => {
     ).toMatchSnapshot('hasArticleReplyWithMorePositiveFeedback = false');
   });
 
+  it('filters via articleRepliesFrom', async () => {
+    expect(
+      await gql`
+        {
+          ListArticles(filter: { articleRepliesFrom: { userId: "user1" } }) {
+            edges {
+              node {
+                id
+                articleReplies(status: NORMAL) {
+                  user {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        }
+      `({}, { appId: 'WEBSITE' })
+    ).toMatchSnapshot('has articleReply from user1');
+
+    expect(
+      await gql`
+        {
+          ListArticles(
+            filter: { articleRepliesFrom: { userId: "user1", exists: false } }
+          ) {
+            edges {
+              node {
+                id
+                articleReplies(status: NORMAL) {
+                  user {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        }
+      `({}, { appId: 'WEBSITE' })
+    ).toMatchSnapshot('do not have articleReply from user1');
+  });
+
   afterAll(() => unloadFixtures(fixtures));
 });

--- a/src/graphql/queries/__tests__/ListReplies.js
+++ b/src/graphql/queries/__tests__/ListReplies.js
@@ -136,6 +136,30 @@ describe('ListReplies', () => {
         }
       `()
     ).toMatchSnapshot('types = RUMOR, NOT_RUMOR');
+
+    expect(
+      await gql`
+        {
+          ListReplies(filter: { userId: "foo" }) {
+            edges {
+              node {
+                id
+                user {
+                  id
+                }
+              }
+            }
+            totalCount
+          }
+        }
+      `(
+        {},
+        {
+          userId: 'foo',
+          appId: 'test',
+        }
+      )
+    ).toMatchSnapshot('userId = foo');
   });
 
   it('filters by moreLikeThis and given text, find replies containing hyperlinks with the said text', async () => {

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
@@ -480,6 +480,75 @@ Object {
 }
 `;
 
+exports[`ListArticles filters via articleRepliesFrom: do not have articleReply from user1 1`] = `
+Object {
+  "data": Object {
+    "ListArticles": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "articleReplies": Array [
+              Object {
+                "user": null,
+              },
+              Object {
+                "user": null,
+              },
+              Object {
+                "user": null,
+              },
+            ],
+            "id": "listArticleTest4",
+          },
+        },
+        Object {
+          "node": Object {
+            "articleReplies": Array [],
+            "id": "listArticleTest3",
+          },
+        },
+        Object {
+          "node": Object {
+            "articleReplies": Array [
+              Object {
+                "user": null,
+              },
+            ],
+            "id": "listArticleTest2",
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`ListArticles filters via articleRepliesFrom: has articleReply from user1 1`] = `
+Object {
+  "data": Object {
+    "ListArticles": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "articleReplies": Array [
+              Object {
+                "user": Object {
+                  "id": "user1",
+                },
+              },
+              Object {
+                "user": null,
+              },
+            ],
+            "id": "listArticleTest1",
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`ListArticles lists all articles 1`] = `
 Object {
   "data": Object {
@@ -734,18 +803,18 @@ Object {
       "edges": Array [
         Object {
           "node": Object {
-            "id": "listArticleTest1",
+            "id": "listArticleTest2",
           },
         },
         Object {
           "node": Object {
-            "id": "listArticleTest2",
+            "id": "listArticleTest1",
           },
         },
       ],
       "pageInfo": Object {
-        "firstCursor": "WzEuODk3MTIsImxpc3RBcnRpY2xlVGVzdDEiXQ==",
-        "lastCursor": "WzAuNjkzMTQ3MiwibGlzdEFydGljbGVUZXN0MiJd",
+        "firstCursor": "WzEsImxpc3RBcnRpY2xlVGVzdDIiXQ==",
+        "lastCursor": "WzEsImxpc3RBcnRpY2xlVGVzdDEiXQ==",
       },
       "totalCount": 2,
     },

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
@@ -723,12 +723,6 @@ Object {
 
 exports[`ListArticles throws error when author filter is not set correctly 1`] = `
 Array [
-  [GraphQLError: Both appId and userId must be specified at once],
-]
-`;
-
-exports[`ListArticles throws error when author filter is not set correctly 2`] = `
-Array [
   [GraphQLError: fromUserOfArticleId does not match any existing articles],
 ]
 `;

--- a/src/graphql/queries/__tests__/__snapshots__/ListReplies.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListReplies.js.snap
@@ -247,6 +247,26 @@ Object {
 }
 `;
 
+exports[`ListReplies filters: userId = foo 1`] = `
+Object {
+  "data": Object {
+    "ListReplies": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "userFoo",
+            "user": Object {
+              "id": "foo",
+            },
+          },
+        },
+      ],
+      "totalCount": 1,
+    },
+  },
+}
+`;
+
 exports[`ListReplies handles selfOnly filter properly if not logged in 1`] = `
 Object {
   "data": Object {


### PR DESCRIPTION
Fixes #165 

## New Feature
- Implements `articleRepliesFrom` in #165 
  - Drops `appId` because `userId` should be sufficient according to [`userId` / `appId` management proposal](https://g0v.hackmd.io/ZcoUOX_-RQSkJyl5xz4_Zg#%E6%96%B9%E5%90%91-2-%E9%87%9D%E5%B0%8D%E6%AF%8F%E5%80%8B-backend-user-%E9%83%BD%E7%94%A2%E7%94%9F%E4%B8%80%E5%80%8B-user-document)
  - I cannot think of any useful use case filtering article-reply's `appId` yet
- Adds `userId` and `appId` to `ListReplies` filter, so that `ListArticles`, `ListReplies` filters work the same as `ListArticleReplyFeedbacks`'s.

## Refactor
- Removes the limitation that requires `userId` and `appId` must be specified together in `ListArticles` filter
  - Previously we use `userId`-`appId` pair to identify users. However in the future [using only  `userId` should be sufficient](https://g0v.hackmd.io/ZcoUOX_-RQSkJyl5xz4_Zg#%E6%96%B9%E5%90%91-2-%E9%87%9D%E5%B0%8D%E6%AF%8F%E5%80%8B-backend-user-%E9%83%BD%E7%94%A2%E7%94%9F%E4%B8%80%E5%80%8B-user-document), thus removing the restriction here.

## Bugfix
- Fixes `categoryIds` and `hasArticleReplyWithMorePositiveFeedback`, which unions its results when used with other filters and is incorrect
  - Similar to #171, please see #171 for explanation.