### PR TITLE
use parameter getter for createArticleCategory Mutation to avoid re-compilation

### DIFF
--- a/src/graphql/mutations/CreateArticleCategory.js
+++ b/src/graphql/mutations/CreateArticleCategory.js
@@ -74,9 +74,9 @@ export async function createArticleCategory({
             HashMap ar = found.get();
             if (ar.get('status').equals('DELETED')) {
               ar.put('status', 'NORMAL');
-              ar.put('userId', '${userId}');
-              ar.put('appId', '${appId}');
-              ar.put('updatedAt', '${now}');
+              ar.put('userId', params.articleCategory.get('userId'));
+              ar.put('appId', params.articleCategory.get('appId'));
+              ar.put('updatedAt', params.articleCategory.get('updatedAt'));
             } else {
               ctx.op = 'none';
             }


### PR DESCRIPTION
try to solve dynamic script compilation problem by using the same script in this mutation

related discussion:
![image](https://user-images.githubusercontent.com/4010549/83629327-77cc2380-a5cc-11ea-9724-2aeaccf42733.png)
![image](https://user-images.githubusercontent.com/4010549/83629337-7d296e00-a5cc-11ea-98ce-04b0d7f0e9d3.png)


reference:
https://stackoverflow.com/questions/60234600/too-many-dynamic-script-compilations-within-max-75-5m