### PR TITLE
Allow multiple origins for one appId

### DIFF
--- a/src/checkHeaders.js
+++ b/src/checkHeaders.js
@@ -44,9 +44,16 @@ async function checkAppId(ctx, next) {
 
   return cors({
     credentials: true,
-    // cors can skip processing only when origin is function @@
-    // if we don't pass function here, cors() will stop nothing.
-    origin: () => origin,
+    origin: ctx => {
+      const allowedOrigins = origin.split(',');
+      if (allowedOrigins.includes(ctx.get('Origin'))) return ctx.get('Origin');
+
+      // CORS check fails.
+      // Since returning null is not recommended, we just return one valid origin here.
+      // Ref: https://w3c.github.io/webappsec-cors-for-developers/#avoid-returning-access-control-allow-origin-null
+      //
+      return allowedOrigins[0];
+    },
   })(ctx, next);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -97,7 +97,10 @@ const apolloServer = new ApolloServer({
   },
 });
 
-apolloServer.applyMiddleware({ app });
+apolloServer.applyMiddleware({
+  app,
+  cors: false, // checkHeaders already managed CORS, don't mess up with that
+});
 
 const port = process.env.PORT || 5000;
 


### PR DESCRIPTION
Currently, rumors-api is designed to lock browser apps to a certain origin. This PR allows multiple origins can be allowed for one browser app.

- Currently we apply this to the only browser app, `RUMORS_SITE`, thus we handle `process.env.RUMORS_SITE_CORS_ORIGIN` exclusively. This is subject to change in future PRs when we introduce multiple apps, but the basic logic should be similar.
- The CORS origin setting is also used in login redirects, restricting browser to only redirect back to allowed origins. We made the following changes to the login redirect mechanism to support multiple domains:
    1. Support comma separated `process.env.RUMORS_SITE_CORS_ORIGIN` string
    2. Store which origin the user is from when login process is initiated. When redirecting back, first check if the origin is valid, then redirect the user back to that specific origin.
- I found a bug that actually `checkHeader` on production **does not stop any requests** -- this is because apollo-server adds a CORS middleware [that permits EVERYTHING](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-server-koa/src/ApolloServer.ts#L159-L161) by default. I added [`cors: false` to `applyMiddleware`](https://www.apollographql.com/docs/apollo-server/api/apollo-server/#apolloserverapplymiddleware) to tell apollo-server to mind its own business and don't mess up with our CORS setup.

This PR makes the following setup possible:
- `en.cofacts.org`, `zh.cofacts.org`, `www.cofacts.org` all connects to `api.cofacts.org` without problem -- just set the above origins in `RUMORS_SITE_CORS_ORIGIN`
- When logging in from `zh.cofacts.org`, the user will be redirect back to `zh.cofacts.org`, rather than other domains.