### PR TITLE
Add CORS origin for LINE bot LIFF

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -14,6 +14,7 @@ HTTP_HEADER_APP_SECRET=x-app-secret
 
 # official web clients
 RUMORS_SITE_CORS_ORIGIN=http://localhost:3000
+RUMORS_LINE_BOT_CORS_ORIGIN=http://localhost:5001
 
 # official line bot client
 RUMORS_LINE_BOT_SECRET=secret

--- a/src/checkHeaders.js
+++ b/src/checkHeaders.js
@@ -33,6 +33,10 @@ async function checkAppId(ctx, next) {
     // // because ctx.user set by passport as well
     //
     // TODO: Fill up origin from DB according to appId
+  } else if (appId === 'RUMORS_LINE_BOT') {
+    // Shortcut for official rumors-line-bot LIFF -- no DB queries
+    origin = process.env.RUMORS_LINE_BOT_CORS_ORIGIN;
+    ctx.appId = 'RUMORS_LINE_BOT';
   } else {
     // No header is given. Allow localhost access only.
     // FIXME: After developer key function rolls out, these kind of request


### PR DESCRIPTION
This is the temp solution for adding more app id (rumors-line-bot's LIFF).

Real solution will come in branch `create-user`; before that, let's just add another env var for the LINE bot.

Related code: https://github.com/cofacts/rumors-line-bot/blob/e75463b64cb4926b74f44a08e5b013a65c616c93/src/liff/lib.js#L178