### PR TITLE
Load more reply request at once

### DIFF
--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -129,7 +129,7 @@ const Article = new GraphQLObjectType({
       resolve: async ({ id }, args, { loaders }) =>
         loaders.searchResultLoader.load({
           index: 'replyrequests',
-          body: { query: { term: { articleId: id } } },
+          body: { query: { term: { articleId: id } }, size: 1000 },
         }),
     },
     replyRequestCount: { type: GraphQLInt },

--- a/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
+++ b/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
@@ -140,8 +140,9 @@ export default {
   ...Array.from(new Array(11)).reduce((mockMap, _, i) => {
     mockMap[`/replyrequests/doc/popular${i}`] = {
       articleId: 'manyRequests',
-      userId: 'fakeUser',
+      userId: `fakeUser ${i}`,
       appId: 'LINE',
+      reason: `Reason ${i}`,
     };
     return mockMap;
   }, {}),

--- a/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
+++ b/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
@@ -39,7 +39,7 @@ export default {
     ],
     normalArticleReplyCount: 1,
     references: [{ type: 'LINE' }],
-    replyRequestCount: 1,
+    replyRequestCount: 2,
 
     /**
      * Added for tests:
@@ -83,6 +83,10 @@ export default {
     ],
     normalArticleReplyCount: 1,
     references: [{ type: 'LINE' }],
+  },
+  '/articles/doc/manyRequests': {
+    text: 'Popular',
+    replyRequestCount: 11,
   },
   '/replies/doc/bar': {
     text: 'bar',
@@ -132,4 +136,13 @@ export default {
     title: '免費訊息詐騙',
     description: '詐騙貼圖、假行銷手法。',
   },
+
+  ...Array.from(new Array(11)).reduce((mockMap, _, i) => {
+    mockMap[`/replyrequests/doc/popular${i}`] = {
+      articleId: 'manyRequests',
+      userId: 'fakeUser',
+      appId: 'LINE',
+    };
+    return mockMap;
+  }, {}),
 };

--- a/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
+++ b/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
@@ -47,6 +47,22 @@ describe('GetReplyAndGetArticle', () => {
       ).toMatchSnapshot();
     });
 
+    it('fetches more than 10 reply requests', async () => {
+      expect(
+        await gql`
+          {
+            GetArticle(id: "manyRequests") {
+              text
+              replyRequestCount
+              replyRequests {
+                reason
+              }
+            }
+          }
+        `({}, { userId: 'fakeUser', appId: 'LINE' })
+      ).toMatchSnapshot();
+    });
+
     it('should allow filtering article replies', async () => {
       expect(
         await gql`

--- a/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
@@ -54,6 +54,52 @@ Object {
 }
 `;
 
+exports[`GetReplyAndGetArticle GetArticle fetches more than 10 reply requests 1`] = `
+Object {
+  "data": Object {
+    "GetArticle": Object {
+      "replyRequestCount": 11,
+      "replyRequests": Array [
+        Object {
+          "reason": "Reason 0",
+        },
+        Object {
+          "reason": "Reason 1",
+        },
+        Object {
+          "reason": "Reason 2",
+        },
+        Object {
+          "reason": "Reason 3",
+        },
+        Object {
+          "reason": "Reason 4",
+        },
+        Object {
+          "reason": "Reason 5",
+        },
+        Object {
+          "reason": "Reason 6",
+        },
+        Object {
+          "reason": "Reason 7",
+        },
+        Object {
+          "reason": "Reason 8",
+        },
+        Object {
+          "reason": "Reason 9",
+        },
+        Object {
+          "reason": "Reason 10",
+        },
+      ],
+      "text": "Popular",
+    },
+  },
+}
+`;
+
 exports[`GetReplyAndGetArticle GetArticle get specified article and articleCategories with DELETED status 1`] = `
 Object {
   "data": Object {
@@ -106,7 +152,7 @@ Object {
               "id": "foo3",
               "text": "Lorum ipsum Lorum ipsum Lorum ipsum",
             },
-            "score": 0.37905684,
+            "score": 0.9489213,
           },
           Object {
             "cursor": "WyJmb28yIl0=",
@@ -114,7 +160,7 @@ Object {
               "id": "foo2",
               "text": "Lorum ipsum Lorum ipsum",
             },
-            "score": 0.3672113,
+            "score": 0.9210748,
           },
         ],
       },
@@ -135,7 +181,7 @@ Object {
               "id": "foo3",
               "text": "Lorum ipsum Lorum ipsum Lorum ipsum",
             },
-            "score": 0.37905684,
+            "score": 0.9489213,
           },
           Object {
             "cursor": "WyJmb28yIl0=",
@@ -143,7 +189,7 @@ Object {
               "id": "foo2",
               "text": "Lorum ipsum Lorum ipsum",
             },
-            "score": 0.3672113,
+            "score": 0.9210748,
           },
         ],
       },
@@ -159,20 +205,20 @@ Object {
       "relatedArticles": Object {
         "edges": Array [
           Object {
-            "cursor": "WzAuMzY3MjExMywiZm9vMiJd",
+            "cursor": "WzAuOTIxMDc0OCwiZm9vMiJd",
             "node": Object {
               "id": "foo2",
               "text": "Lorum ipsum Lorum ipsum",
             },
-            "score": 0.3672113,
+            "score": 0.9210748,
           },
           Object {
-            "cursor": "WzAuMzc5MDU2ODQsImZvbzMiXQ==",
+            "cursor": "WzAuOTQ4OTIxMywiZm9vMyJd",
             "node": Object {
               "id": "foo3",
               "text": "Lorum ipsum Lorum ipsum Lorum ipsum",
             },
-            "score": 0.37905684,
+            "score": 0.9489213,
           },
         ],
       },
@@ -253,7 +299,7 @@ Object {
         },
       ],
       "replyCount": 1,
-      "replyRequestCount": 1,
+      "replyRequestCount": 2,
       "replyRequests": Array [
         Object {
           "feedbackCount": 2,


### PR DESCRIPTION
Allows more than 10 reply requests being loaded in `ArticleType`.

This fixes #164 

Note: In the unit test I added a new article, thus `scores` in snapshots changed.