### PR TITLE
modify command line options for fetchStatsFromGA script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,12 +175,7 @@ $ docker-compose exec api node_modules/.bin/babel-node src/scripts/cleanupUrls.j
 $ node_modules/.bin/babel-node src/scripts/fetchStatsFromGA.js
 ```
 
--  To fetch stats for a certain date range, run the above command with 
-```--startDate=YYYY-MM-DD --endDate=YYYY-MM-DD```
-
--  If the script is ran for the first time, run the above command with
-```--loadScript```
-
+-  For more options, run the above script with `--help` or see the file level comments.
 
 
 ## Troubleshooting 

--- a/src/scripts/__tests__/__snapshots__/fetchStatsFromGA.js.snap
+++ b/src/scripts/__tests__/__snapshots__/fetchStatsFromGA.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`fetchStatsFromGA helper functions requestBodyBuilder should return right request body for different source and doc types: LINE_article_isCron=false 1`] = `
+exports[`fetchStatsFromGA helper functions requestBodyBuilder should return right request body for different source and doc types: LINE_article_useContentGroup=false 1`] = `
 Object {
   "dateRanges": Array [
     Object {
@@ -40,7 +40,7 @@ Object {
 }
 `;
 
-exports[`fetchStatsFromGA helper functions requestBodyBuilder should return right request body for different source and doc types: LINE_article_isCron=true 1`] = `
+exports[`fetchStatsFromGA helper functions requestBodyBuilder should return right request body for different source and doc types: LINE_article_useContentGroup=true 1`] = `
 Object {
   "dateRanges": Array [
     Object {
@@ -80,7 +80,7 @@ Object {
 }
 `;
 
-exports[`fetchStatsFromGA helper functions requestBodyBuilder should return right request body for different source and doc types: LINE_reply_isCron=false 1`] = `
+exports[`fetchStatsFromGA helper functions requestBodyBuilder should return right request body for different source and doc types: LINE_reply_useContentGroup=false 1`] = `
 Object {
   "dateRanges": Array [
     Object {
@@ -120,7 +120,7 @@ Object {
 }
 `;
 
-exports[`fetchStatsFromGA helper functions requestBodyBuilder should return right request body for different source and doc types: LINE_reply_isCron=true 1`] = `
+exports[`fetchStatsFromGA helper functions requestBodyBuilder should return right request body for different source and doc types: LINE_reply_useContentGroup=true 1`] = `
 Object {
   "dateRanges": Array [
     Object {
@@ -160,7 +160,7 @@ Object {
 }
 `;
 
-exports[`fetchStatsFromGA helper functions requestBodyBuilder should return right request body for different source and doc types: WEB_article_isCron=false 1`] = `
+exports[`fetchStatsFromGA helper functions requestBodyBuilder should return right request body for different source and doc types: WEB_article_useContentGroup=false 1`] = `
 Object {
   "dateRanges": Array [
     Object {
@@ -200,7 +200,7 @@ Object {
 }
 `;
 
-exports[`fetchStatsFromGA helper functions requestBodyBuilder should return right request body for different source and doc types: WEB_article_isCron=true 1`] = `
+exports[`fetchStatsFromGA helper functions requestBodyBuilder should return right request body for different source and doc types: WEB_article_useContentGroup=true 1`] = `
 Object {
   "dateRanges": Array [
     Object {
@@ -240,7 +240,7 @@ Object {
 }
 `;
 
-exports[`fetchStatsFromGA helper functions requestBodyBuilder should return right request body for different source and doc types: WEB_reply_isCron=false 1`] = `
+exports[`fetchStatsFromGA helper functions requestBodyBuilder should return right request body for different source and doc types: WEB_reply_useContentGroup=false 1`] = `
 Object {
   "dateRanges": Array [
     Object {
@@ -280,7 +280,7 @@ Object {
 }
 `;
 
-exports[`fetchStatsFromGA helper functions requestBodyBuilder should return right request body for different source and doc types: WEB_reply_isCron=true 1`] = `
+exports[`fetchStatsFromGA helper functions requestBodyBuilder should return right request body for different source and doc types: WEB_reply_useContentGroup=true 1`] = `
 Object {
   "dateRanges": Array [
     Object {
@@ -877,16 +877,12 @@ Array [
   Array [
     "WEB",
     undefined,
-    Object {
-      "isCron": true,
-    },
+    undefined,
   ],
   Array [
     "LINE",
     undefined,
-    Object {
-      "isCron": true,
-    },
+    undefined,
   ],
 ]
 `;
@@ -898,8 +894,8 @@ Array [
     undefined,
     Object {
       "endDate": "today",
-      "isCron": false,
       "startDate": "2020-07-10",
+      "useContentGroup": false,
     },
   ],
   Array [
@@ -907,8 +903,8 @@ Array [
     undefined,
     Object {
       "endDate": "today",
-      "isCron": false,
       "startDate": "2020-07-10",
+      "useContentGroup": false,
     },
   ],
 ]
@@ -960,9 +956,7 @@ Array [
   Array [
     "WEB",
     undefined,
-    Object {
-      "isCron": true,
-    },
+    undefined,
   ],
   Array [
     "WEB",
@@ -970,9 +964,7 @@ Array [
       "article": 100,
       "reply": 100,
     },
-    Object {
-      "isCron": true,
-    },
+    undefined,
   ],
   Array [
     "WEB",
@@ -980,16 +972,12 @@ Array [
       "article": 200,
       "reply": -1,
     },
-    Object {
-      "isCron": true,
-    },
+    undefined,
   ],
   Array [
     "LINE",
     undefined,
-    Object {
-      "isCron": true,
-    },
+    undefined,
   ],
   Array [
     "LINE",
@@ -997,9 +985,7 @@ Array [
       "article": 100,
       "reply": 100,
     },
-    Object {
-      "isCron": true,
-    },
+    undefined,
   ],
   Array [
     "LINE",
@@ -1007,9 +993,7 @@ Array [
       "article": -1,
       "reply": 200,
     },
-    Object {
-      "isCron": true,
-    },
+    undefined,
   ],
 ]
 `;


### PR DESCRIPTION
- remove date validation to allow relative date pattern
- add useContentGroup option instead of guessing from start/end dates

note that functions in `util/date.js` are no longer referenced in the code base, but I'd like to keep them for now.
Will remove the file if they remain unused when the project is completed.