### PR TITLE
Enable Samesite cookie on API server

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -22,6 +22,8 @@ RUMORS_LINE_BOT_SECRET=secret
 # Cookie related setup, expire time default to 86400 * 1000 * 14 milliseconds (14 days)
 COOKIE_MAXAGE=1209600000
 COOKIE_SECRETS=foo,bar
+# Set Samesite=none to enable cross-site login
+COOKIE_SAMESITE_NONE=1
 
 # Login-service credentials
 FACEBOOK_APP_ID=YOUR_FB_ID

--- a/.env.sample
+++ b/.env.sample
@@ -23,14 +23,20 @@ RUMORS_LINE_BOT_SECRET=secret
 COOKIE_MAXAGE=1209600000
 COOKIE_SECRETS=foo,bar
 
-# Set Samesite=none and secure flag to enable cross-site login.
-# If this is turned on, either X-Forwarded-Proto or https must be used, or Koa will throw error
-# preventing us from setting the secure flag.
-COOKIE_SAMESITE_NONE=1
-
-# If we should trust proxy headers (x-forwarded-*)
+# If we should trust proxy headers (x-forwarded-*).
 #
-TRUST_PROXY_HEADERS=1
+# Note: don't turn this on unless the server is behind a reversed proxy (like nginx or cloudflare).
+#
+TRUST_PROXY_HEADERS=
+
+# Set Samesite=none and secure flag to enable cross-site login.
+# See: https://github.com/cofacts/rumors-api/issues/186#issuecomment-644612628
+#
+# Note: don't turn this on unless you have HTTPS or X-Forwarded-Proto header set.
+# Koa will throw error preventing us from setting the secure flag if we don't satisfy the condition
+# above.
+#
+COOKIE_SAMESITE_NONE=
 
 # Login-service credentials
 FACEBOOK_APP_ID=YOUR_FB_ID

--- a/.env.sample
+++ b/.env.sample
@@ -22,8 +22,15 @@ RUMORS_LINE_BOT_SECRET=secret
 # Cookie related setup, expire time default to 86400 * 1000 * 14 milliseconds (14 days)
 COOKIE_MAXAGE=1209600000
 COOKIE_SECRETS=foo,bar
-# Set Samesite=none to enable cross-site login
+
+# Set Samesite=none and secure flag to enable cross-site login.
+# If this is turned on, either X-Forwarded-Proto or https must be used, or Koa will throw error
+# preventing us from setting the secure flag.
 COOKIE_SAMESITE_NONE=1
+
+# If we should trust proxy headers (x-forwarded-*)
+#
+TRUST_PROXY_HEADERS=1
 
 # Login-service credentials
 FACEBOOK_APP_ID=YOUR_FB_ID
@@ -35,7 +42,6 @@ TWITTER_CALLBACK_URL=http://localhost:5000/callback/twitter
 GITHUB_CLIENT_ID=YOUR_GITHUB_CLIENT_ID
 GITHUB_SECRET=YOUR_GITHUB_CLIENT_SECRET
 GITHUB_CALLBACK_URL=http://localhost:5000/callback/github
-
 
 #Google Analytics Related settings
 GOOGLE_OAUTH_KEY_PATH=PATH_TO_SERVICE_ACCOUNT_KEY

--- a/package-lock.json
+++ b/package-lock.json
@@ -12022,9 +12022,9 @@
       }
     },
     "koa-session2": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/koa-session2/-/koa-session2-2.2.6.tgz",
-      "integrity": "sha512-S0idBv24v24iu8ZECL8/t15jCnwnGRZG+IG9bLWEVn0EWX5MsU2NbSED6buyKIlCaZn0IKUCPQxkej1H1X1m4g=="
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/koa-session2/-/koa-session2-2.2.10.tgz",
+      "integrity": "sha512-5t6uqSvtM2pj0TEeYk/1uluNVKvrWDpEFuyFoOXUtyy4f/Ic3c13OnU+/ku5AKhWxFWshLZ+YGd3F67y0djD1Q=="
     },
     "koa-static": {
       "version": "5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6363,12 +6363,19 @@
       "dev": true
     },
     "cookies": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.1.tgz",
-      "integrity": "sha1-fIphX1SBxhq58WyDNzG8uPZjuZs=",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
+      "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
       "requires": {
-        "depd": "~1.1.1",
-        "keygrip": "~1.0.2"
+        "depd": "~2.0.0",
+        "keygrip": "~1.1.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        }
       }
     },
     "copy-descriptor": {
@@ -11872,9 +11879,12 @@
       "integrity": "sha1-cWCpTy6uYzQ20s746t0M4jI4Z3k="
     },
     "keygrip": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.2.tgz",
-      "integrity": "sha1-rTKXxVcGneqLz+ek+kkbdcXd65E="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.1.0.tgz",
+      "integrity": "sha512-iYSchDJ+liQ8iwbSI2QqsQOvqv58eJCEanyJPJi+Khyu8smkcKSFUCbPwzFcL7YVtZ6eONjqRX/38caJ7QjRAQ==",
+      "requires": {
+        "tsscmp": "1.0.6"
+      }
     },
     "kind-of": {
       "version": "6.0.3",
@@ -11889,34 +11899,33 @@
       "dev": true
     },
     "koa": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.5.1.tgz",
-      "integrity": "sha512-cchwbMeG2dv3E2xTAmheDAuvR53tPgJZN/Hf1h7bTzJLSPcFZp8/t5+bNKJ6GaQZoydhZQ+1GNruhKdj3lIrug==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.13.0.tgz",
+      "integrity": "sha512-i/XJVOfPw7npbMv67+bOeXr3gPqOAw6uh5wFyNs3QvJ47tUx3M3V9rIE0//WytY42MKz4l/MXKyGkQ2LQTfLUQ==",
       "requires": {
-        "accepts": "^1.2.2",
-        "content-disposition": "~0.5.0",
-        "content-type": "^1.0.0",
-        "cookies": "~0.7.0",
-        "debug": "*",
+        "accepts": "^1.3.5",
+        "cache-content-type": "^1.0.0",
+        "content-disposition": "~0.5.2",
+        "content-type": "^1.0.4",
+        "cookies": "~0.8.0",
+        "debug": "~3.1.0",
         "delegates": "^1.0.0",
-        "depd": "^1.1.0",
-        "destroy": "^1.0.3",
-        "error-inject": "~1.0.0",
-        "escape-html": "~1.0.1",
-        "fresh": "^0.5.2",
-        "http-assert": "^1.1.0",
-        "http-errors": "^1.2.8",
-        "is-generator-function": "^1.0.3",
-        "koa-compose": "^4.0.0",
+        "depd": "^1.1.2",
+        "destroy": "^1.0.4",
+        "encodeurl": "^1.0.2",
+        "escape-html": "^1.0.3",
+        "fresh": "~0.5.2",
+        "http-assert": "^1.3.0",
+        "http-errors": "^1.6.3",
+        "is-generator-function": "^1.0.7",
+        "koa-compose": "^4.1.0",
         "koa-convert": "^1.2.0",
-        "koa-is-json": "^1.0.0",
-        "mime-types": "^2.0.7",
-        "on-finished": "^2.1.0",
-        "only": "0.0.2",
-        "parseurl": "^1.3.0",
-        "statuses": "^1.2.0",
-        "type-is": "^1.5.5",
-        "vary": "^1.0.0"
+        "on-finished": "^2.3.0",
+        "only": "~0.0.2",
+        "parseurl": "^1.3.2",
+        "statuses": "^1.5.0",
+        "type-is": "^1.6.16",
+        "vary": "^1.1.2"
       }
     },
     "koa-bodyparser": {
@@ -11951,11 +11960,6 @@
           }
         }
       }
-    },
-    "koa-is-json": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/koa-is-json/-/koa-is-json-1.0.0.tgz",
-      "integrity": "sha1-JzwH7c3Ljfaiwat9We52SRRR7BQ="
     },
     "koa-passport": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "graphql": "^15.0.0",
     "grpc": "^1.11.0",
     "kcors": "^2.2.1",
-    "koa": "^2.5.0",
+    "koa": "^2.13.0",
     "koa-bodyparser": "^4.0.0",
     "koa-passport": "^4.0.1",
     "koa-router": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "koa-bodyparser": "^4.0.0",
     "koa-passport": "^4.0.1",
     "koa-router": "^8.0.0",
-    "koa-session2": "^2.0.0",
+    "koa-session2": "^2.2.9",
     "koa-static": "^5.0.0",
     "node-fetch": "^2.2.0",
     "passport-facebook": "^3.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -41,11 +41,17 @@ app.use(
 
 app.keys = (process.env.COOKIE_SECRETS || '').split(',');
 
+// See: https://github.com/cofacts/rumors-api/issues/186#issuecomment-644612628
+const samesiteConfig = process.env.COOKIE_SAMESITE_NONE
+  ? { sameSite: 'none', secure: true }
+  : {};
+
 app.use(
   session({
     store: new CookieStore({ password: app.keys[0] }),
     signed: true,
     maxAge: process.env.COOKIE_MAXAGE,
+    ...samesiteConfig,
   })
 );
 app.use(passport.initialize());

--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,7 @@ app.use(
 );
 
 app.keys = (process.env.COOKIE_SECRETS || '').split(',');
+app.proxy = !!process.env.TRUST_PROXY_HEADERS;
 
 // See: https://github.com/cofacts/rumors-api/issues/186#issuecomment-644612628
 const samesiteConfig = process.env.COOKIE_SAMESITE_NONE

--- a/src/index.js
+++ b/src/index.js
@@ -42,7 +42,6 @@ app.use(
 app.keys = (process.env.COOKIE_SECRETS || '').split(',');
 app.proxy = !!process.env.TRUST_PROXY_HEADERS;
 
-// See: https://github.com/cofacts/rumors-api/issues/186#issuecomment-644612628
 const samesiteConfig = process.env.COOKIE_SAMESITE_NONE
   ? { sameSite: 'none', secure: true }
   : {};


### PR DESCRIPTION
<img width="1439" alt="截圖 2020-08-20 上午2 50 54" src="https://user-images.githubusercontent.com/108608/90677503-09743480-e290-11ea-950f-a14136eebffb.png">

This PR fixes #186 via:

- Upgrades koa and koa-session2 for `SameSite` support
- Turn on `samesite` and `secure` for session cookies
    - If `secure` is not set, session cookies (`koa:sess` and `koa:sess.sig`) won't have Secure flag, and the browser does not apply SameSite=None
    - Adds env var `COOKIE_SAMESITE_NONE` to toggle it. In some case `samesite` may be not required.
- Trust proxy headers
    - This allows Koa to recognize `x-forwarded-proto` and send `secure: true` when calling `new Cookies()`.
        - Related code analysis: https://github.com/koajs/koa/issues/974#issuecomment-307232498
    - If `secure: true` is not set on `new Cookies()`, cookie middleware will throw exception saying that `secure` flag is only available under secure connections when we try to set a secure cookie.
    - Add env var `TRUST_PROXY_HEADERS` to toggle it. This is because in some configuration there may be no proxies in front of koa. In that scenario we had better not trust proxy headers.
- Env variables & `x-forwarded-proto` setup: see cofacts/rumors-deploy#13
