### PR TITLE
Fix cleanupUrls script

### DIFF
--- a/src/scripts/__fixtures__/cleanupUrls.js
+++ b/src/scripts/__fixtures__/cleanupUrls.js
@@ -47,4 +47,12 @@ export default {
     canonical: 'bar.com',
     fetchedAt: '2018-01-01T00:00:00Z', // more than 1 day ago
   },
+  ...Array.from(Array(100)).reduce((fixtures, _, i) => {
+    fixtures[`/urls/doc/quantityTest${i}`] = {
+      url: `not-exist${i}.com`,
+      canonical: `not-exist${i}.com`,
+      fetchedAt: '2018-01-01T00:00:00Z', // more than 1 day ago
+    };
+    return fixtures;
+  }, {}),
 };

--- a/src/scripts/cleanupUrls.js
+++ b/src/scripts/cleanupUrls.js
@@ -50,7 +50,9 @@ async function processUrls(processFn) {
   console.info(`${processedCount} / ${total} Processed`);
 
   while (processedCount < total) {
-    const { hits, _scroll_id } = await client.scroll({
+    const {
+      body: { hits, _scroll_id },
+    } = await client.scroll({
       scroll: '30s',
       scrollId,
     });


### PR DESCRIPTION
Fixes #210.

As described in #210, the URL cleaning cronjob always fails on production.

## Root cause
When we bump elasticsearch client in #153, there was a breaking change that wraps return value of elasticsearch client with an extra `{body: }`.

At that time we updated all elasticsearch client return values that unit test covered; unfortunately, there is one call-site of elasticsearch client not updated. The call site will not be executed until there are more than 100 `urls` to scan and delete.

## Proposed fix
1. Add 100 more fixture for `cleanupUrls` so that it fails unit test
2. Fix `cleanupUrls` to make test pass
