### PR TITLE
Interface for connection related types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8766,9 +8766,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.0.0.tgz",
-      "integrity": "sha512-ZyVO1xIF9F+4cxfkdhOJINM+51B06Friuv4M66W7HzUOeFd+vNzUn4vtswYINPi6sysjf1M2Ri/rwZALqgwbaQ=="
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
+      "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w=="
     },
     "graphql-extensions": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "form-data": "^3.0.0",
     "google-protobuf": "^3.0.0",
     "googleapis": "^55.0.0",
-    "graphql": "^15.0.0",
+    "graphql": "^15.3.0",
     "grpc": "^1.11.0",
     "kcors": "^2.2.1",
     "koa": "^2.13.0",

--- a/src/graphql/interfaces/Connection.js
+++ b/src/graphql/interfaces/Connection.js
@@ -1,0 +1,23 @@
+import {
+  GraphQLInterfaceType,
+  GraphQLNonNull,
+  GraphQLList,
+  GraphQLInt,
+} from 'graphql';
+import Edge from './Edge';
+import PageInfo from './PageInfo';
+
+const Connection = new GraphQLInterfaceType({
+  name: 'Connection',
+  description:
+    "Connection model for a list of nodes. Modeled after Relay's GraphQL Server Specification.",
+  fields: {
+    edges: {
+      type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(Edge))),
+    },
+    totalCount: { type: new GraphQLNonNull(GraphQLInt) },
+    pageInfo: { type: new GraphQLNonNull(PageInfo) },
+  },
+});
+
+export default Connection;

--- a/src/graphql/interfaces/Edge.js
+++ b/src/graphql/interfaces/Edge.js
@@ -1,0 +1,13 @@
+import { GraphQLInterfaceType, GraphQLNonNull, GraphQLString } from 'graphql';
+import Node from './Node';
+
+const Edge = new GraphQLInterfaceType({
+  name: 'Edge',
+  description: 'Edge in Connection. Modeled after GraphQL connection model.',
+  fields: {
+    node: { type: new GraphQLNonNull(Node) },
+    cursor: { type: new GraphQLNonNull(GraphQLString) },
+  },
+});
+
+export default Edge;

--- a/src/graphql/interfaces/Node.js
+++ b/src/graphql/interfaces/Node.js
@@ -1,0 +1,12 @@
+import { GraphQLInterfaceType, GraphQLID, GraphQLNonNull } from 'graphql';
+
+const Node = new GraphQLInterfaceType({
+  name: 'Node',
+  description:
+    "Basic entity. Modeled after Relay's GraphQL Server Specification.",
+  fields: {
+    id: { type: new GraphQLNonNull(GraphQLID) },
+  },
+});
+
+export default Node;

--- a/src/graphql/interfaces/PageInfo.js
+++ b/src/graphql/interfaces/PageInfo.js
@@ -1,0 +1,21 @@
+import { GraphQLInterfaceType, GraphQLString } from 'graphql';
+
+const PageInfo = new GraphQLInterfaceType({
+  name: 'PageInfo',
+  description:
+    'PageInfo in Connection. Modeled after GraphQL connection model.',
+  fields: {
+    firstCursor: {
+      description:
+        'The cursor pointing to the first node of the entire collection, regardless of "before" and "after". Can be used to determine if is in the last page. Null when the collection is empty.',
+      type: GraphQLString,
+    },
+    lastCursor: {
+      description:
+        'The cursor pointing to the last node of the entire collection, regardless of "before" and "after". Can be used to determine if is in the last page. Null when the collection is empty.',
+      type: GraphQLString,
+    },
+  },
+});
+
+export default PageInfo;

--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -1,4 +1,6 @@
 import {
+  GraphQLNonNull,
+  GraphQLID,
   GraphQLObjectType,
   GraphQLString,
   GraphQLList,
@@ -19,6 +21,7 @@ import {
   timeRangeInput,
 } from 'graphql/util';
 
+import Node from '../interfaces/Node';
 import Analytics from 'graphql/models/Analytics';
 import ArticleReference from 'graphql/models/ArticleReference';
 import User, { userFieldResolver } from 'graphql/models/User';
@@ -31,8 +34,9 @@ import ReplyRequest from './ReplyRequest';
 
 const Article = new GraphQLObjectType({
   name: 'Article',
+  interfaces: [Node],
   fields: () => ({
-    id: { type: GraphQLString },
+    id: { type: new GraphQLNonNull(GraphQLID) },
     text: { type: GraphQLString },
     createdAt: { type: GraphQLString },
     updatedAt: { type: GraphQLString },

--- a/src/graphql/models/ArticleCategory.js
+++ b/src/graphql/models/ArticleCategory.js
@@ -5,20 +5,32 @@ import {
   GraphQLFloat,
   GraphQLString,
   GraphQLBoolean,
+  GraphQLID,
+  GraphQLNonNull,
 } from 'graphql';
 
+import { createConnectionType, defaultResolveEdges } from 'graphql/util';
+
+import Node from '../interfaces/Node';
 import Article from './Article';
 import User, { userFieldResolver } from './User';
 import Category from './Category';
 import ArticleCategoryFeedback from './ArticleCategoryFeedback';
 import ArticleCategoryStatusEnum from './ArticleCategoryStatusEnum';
 import FeedbackVote from './FeedbackVote';
-import { createConnectionType, defaultResolveEdges } from 'graphql/util';
 
 const ArticleCategory = new GraphQLObjectType({
   name: 'ArticleCategory',
+  interfaces: [Node],
   description: 'The linkage between an Article and a Category',
   fields: () => ({
+    id: {
+      type: new GraphQLNonNull(GraphQLID),
+      resolve({ categoryId, articleId }) {
+        return `${articleId}__${categoryId}`;
+      },
+    },
+
     categoryId: { type: GraphQLString },
 
     category: {

--- a/src/graphql/models/ArticleReplyFeedback.js
+++ b/src/graphql/models/ArticleReplyFeedback.js
@@ -1,6 +1,13 @@
-import { GraphQLObjectType, GraphQLString, GraphQLInt } from 'graphql';
-import FeedbackVote from './FeedbackVote';
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLInt,
+  GraphQLID,
+  GraphQLNonNull,
+} from 'graphql';
 
+import Node from '../interfaces/Node';
+import FeedbackVote from './FeedbackVote';
 import User, { userFieldResolver } from './User';
 import Article from './Article';
 import Reply from './Reply';
@@ -9,8 +16,9 @@ import ArticleReply from './ArticleReply';
 export default new GraphQLObjectType({
   name: 'ArticleReplyFeedback',
   description: 'User feedback to an ArticleReply',
+  interfaces: [Node],
   fields: () => ({
-    id: { type: GraphQLString },
+    id: { type: new GraphQLNonNull(GraphQLID) },
 
     user: {
       type: User,

--- a/src/graphql/models/Category.js
+++ b/src/graphql/models/Category.js
@@ -1,15 +1,22 @@
-import { GraphQLObjectType, GraphQLString } from 'graphql';
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLNonNull,
+  GraphQLID,
+} from 'graphql';
 
 import { createSortType, pagingArgs, getSortArgs } from 'graphql/util';
 
+import Node from '../interfaces/Node';
 import { ArticleCategoryConnection } from './ArticleCategory';
 import ArticleCategoryStatusEnum from './ArticleCategoryStatusEnum';
 
 const Category = new GraphQLObjectType({
   name: 'Category',
   description: 'Category label for specific topic',
+  interfaces: [Node],
   fields: () => ({
-    id: { type: GraphQLString },
+    id: { type: new GraphQLNonNull(GraphQLID) },
     title: { type: GraphQLString },
     description: { type: GraphQLString },
     createdAt: { type: GraphQLString },

--- a/src/graphql/models/Reply.js
+++ b/src/graphql/models/Reply.js
@@ -1,6 +1,13 @@
-import { GraphQLObjectType, GraphQLString, GraphQLList } from 'graphql';
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLList,
+  GraphQLNonNull,
+  GraphQLID,
+} from 'graphql';
 
 import { filterArticleRepliesByStatus } from 'graphql/util';
+import Node from '../interfaces/Node';
 import ReplyTypeEnum from './ReplyTypeEnum';
 import ArticleReplyStatusEnum from './ArticleReplyStatusEnum';
 import ArticleReply from './ArticleReply';
@@ -9,8 +16,9 @@ import Hyperlink from './Hyperlink';
 
 const Reply = new GraphQLObjectType({
   name: 'Reply',
+  interfaces: [Node],
   fields: () => ({
-    id: { type: GraphQLString },
+    id: { type: new GraphQLNonNull(GraphQLID) },
     user: {
       type: User,
       description: 'The user submitted this reply version',

--- a/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
+++ b/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
@@ -203,6 +203,7 @@ describe('GetReplyAndGetArticle', () => {
             GetArticle(id: "foo") {
               text
               articleCategories(status: NORMAL) {
+                id
                 categoryId
                 category {
                   id

--- a/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
@@ -132,6 +132,7 @@ Object {
             "title": "性少數與愛滋病",
           },
           "categoryId": "c1",
+          "id": "foo__c1",
         },
       ],
       "text": "Lorum ipsum",

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
@@ -782,14 +782,7 @@ Object {
 exports[`ListArticles should fail if before and after both exist 1`] = `
 Object {
   "data": Object {
-    "ListArticles": Object {
-      "edges": null,
-      "pageInfo": Object {
-        "firstCursor": "WyJsaXN0QXJ0aWNsZVRlc3Q0Il0=",
-        "lastCursor": "WyJsaXN0QXJ0aWNsZVRlc3QxIl0=",
-      },
-      "totalCount": 4,
-    },
+    "ListArticles": null,
   },
   "errors": Array [
     [GraphQLError: Use of before & after is prohibited.],

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -378,7 +378,7 @@ export function createConnectionType(
           new GraphQLList(
             new GraphQLNonNull(
               new GraphQLObjectType({
-                name: `${typeName}Edges`,
+                name: `${typeName}Edge`,
                 interfaces: [Edge],
                 fields: {
                   node: { type: new GraphQLNonNull(nodeType) },


### PR DESCRIPTION
- Create `Node`, `Edge`, `PageInfo` and `Connection` interfaces and have similar object types inherit from them.
  - This helps components like `<LoadMore>` in rumors-site to create object-agnostic fragments that only retrieves common fields
  - Also defines more strict `NonNull` and `ID` so that their type is more rigorous.
  - When `resolveEdge` errors, the whole request (like `ListArticle`) would return `null` now, rather than return partially in the past. This makes more sense in terms of param error.
- Upgrade graphql-js to get better error message regarding interfaces. see graphql/graphql-js#2513
