### PR TITLE
Make profile page related fields in User object type publically available

### DIFF
--- a/src/graphql/dataLoaders/index.js
+++ b/src/graphql/dataLoaders/index.js
@@ -7,6 +7,7 @@ import articleCategoryFeedbacksLoaderFactory from './articleCategoryFeedbacksLoa
 import searchResultLoaderFactory from './searchResultLoaderFactory';
 import urlLoaderFactory from './urlLoaderFactory';
 import repliedArticleCountLoaderFactory from './repliedArticleCountLoaderFactory';
+import votedArticleReplyFeedbackCountLoaderFactory from './votedArticleReplyFeedbackCountLoaderFactory';
 import userLevelLoaderFactory from './userLevelLoaderFactory';
 
 export default class DataLoaders {
@@ -54,6 +55,13 @@ export default class DataLoaders {
     return this._checkOrSetLoader(
       'repliedArticleCountLoader',
       repliedArticleCountLoaderFactory
+    );
+  }
+
+  get votedArticleReplyFeedbackCountLoader() {
+    return this._checkOrSetLoader(
+      'votedArticleReplyFeedbackCountLoader',
+      votedArticleReplyFeedbackCountLoaderFactory
     );
   }
 

--- a/src/graphql/dataLoaders/index.js
+++ b/src/graphql/dataLoaders/index.js
@@ -7,7 +7,7 @@ import articleCategoryFeedbacksLoaderFactory from './articleCategoryFeedbacksLoa
 import searchResultLoaderFactory from './searchResultLoaderFactory';
 import urlLoaderFactory from './urlLoaderFactory';
 import repliedArticleCountLoaderFactory from './repliedArticleCountLoaderFactory';
-import votedArticleReplyFeedbackCountLoaderFactory from './votedArticleReplyFeedbackCountLoaderFactory';
+import votedArticleReplyCountLoaderFactory from './votedArticleReplyCountLoaderFactory';
 import userLevelLoaderFactory from './userLevelLoaderFactory';
 
 export default class DataLoaders {
@@ -58,10 +58,10 @@ export default class DataLoaders {
     );
   }
 
-  get votedArticleReplyFeedbackCountLoader() {
+  get votedArticleReplyCountLoader() {
     return this._checkOrSetLoader(
-      'votedArticleReplyFeedbackCountLoader',
-      votedArticleReplyFeedbackCountLoaderFactory
+      'votedArticleReplyCountLoader',
+      votedArticleReplyCountLoaderFactory
     );
   }
 

--- a/src/graphql/dataLoaders/votedArticleReplyCountLoaderFactory.js
+++ b/src/graphql/dataLoaders/votedArticleReplyCountLoaderFactory.js
@@ -5,7 +5,7 @@ export default () =>
   new DataLoader(
     /**
      * @param {string[]} userIds - list of userIds
-     * @returns {Promise<number[]>} - number of article reply feedbacks the specified user has voted
+     * @returns {Promise<number[]>} - number of article replies the specified user has voted
      */
     async userIds => {
       const body = userIds.reduce(

--- a/src/graphql/dataLoaders/votedArticleReplyFeedbackCountLoaderFactory.js
+++ b/src/graphql/dataLoaders/votedArticleReplyFeedbackCountLoaderFactory.js
@@ -5,7 +5,7 @@ export default () =>
   new DataLoader(
     /**
      * @param {string[]} userIds - list of userIds
-     * @returns {Promise<number[]>} - replied article count for the specified user
+     * @returns {Promise<number[]>} - number of article reply feedbacks the specified user has voted
      */
     async userIds => {
       const body = userIds.reduce(

--- a/src/graphql/dataLoaders/votedArticleReplyFeedbackCountLoaderFactory.js
+++ b/src/graphql/dataLoaders/votedArticleReplyFeedbackCountLoaderFactory.js
@@ -1,0 +1,30 @@
+import DataLoader from 'dataloader';
+import client from 'util/client';
+
+export default () =>
+  new DataLoader(
+    /**
+     * @param {string[]} userIds - list of userIds
+     * @returns {Promise<number[]>} - replied article count for the specified user
+     */
+    async userIds => {
+      const body = userIds.reduce(
+        (commands, userId) =>
+          commands.concat(
+            {
+              index: 'articlereplyfeedbacks',
+              type: 'doc',
+            },
+            {
+              size: 0,
+              query: { term: { userId } },
+            }
+          ),
+        []
+      );
+
+      return (await client.msearch({ body })).body.responses.map(
+        ({ hits: { total } }) => total
+      );
+    }
+  );

--- a/src/graphql/models/User.js
+++ b/src/graphql/models/User.js
@@ -1,4 +1,9 @@
-import { GraphQLObjectType, GraphQLString, GraphQLInt } from 'graphql';
+import {
+  GraphQLObjectType,
+  GraphQLString,
+  GraphQLInt,
+  GraphQLNonNull,
+} from 'graphql';
 import crypto from 'crypto';
 
 /**
@@ -46,53 +51,65 @@ const User = new GraphQLObjectType({
     facebookId: currentUserOnlyField(GraphQLString),
     githubId: currentUserOnlyField(GraphQLString),
     twitterId: currentUserOnlyField(GraphQLString),
-    repliedArticleCount: currentUserOnlyField(
-      GraphQLInt,
-      (user, args, context) =>
-        context.loaders.repliedArticleCountLoader.load(user.id)
-    ),
+    repliedArticleCount: {
+      type: GraphQLNonNull(GraphQLInt),
+      description: 'Number of articles this user has replied to',
+      resolve: (user, args, context) =>
+        context.loaders.repliedArticleCountLoader
+          .load(user.id)
+          .then(num => num || 0),
+    },
+    votedArticleReplyCount: {
+      type: GraphQLNonNull(GraphQLInt),
+      description: 'Number of article replies this user has given feedbacks',
+      resolve: (user, args, context) =>
+        context.loaders.votedArticleReplyFeedbackCountLoader
+          .load(user.id)
+          .then(num => num || 0),
+    },
+
     level: {
-      type: GraphQLInt,
+      type: new GraphQLNonNull(GraphQLInt),
       async resolve(user, arg, context) {
-        const { level } = await context.loaders.userLevelLoader.load(user.id);
-        return level;
+        const { level } =
+          (await context.loaders.userLevelLoader.load(user.id)) || {};
+        return level || 0;
       },
     },
-    points: currentUserOnlyField(
-      new GraphQLObjectType({
-        name: 'PointInfo',
-        description:
-          "Information of a user's point. Only available for current user.",
-        fields: {
-          total: {
-            type: GraphQLInt,
-            description: 'Points earned by the current user',
+    points: {
+      type: new GraphQLNonNull(
+        new GraphQLObjectType({
+          name: 'PointInfo',
+          description:
+            "Information of a user's point. Only available for current user.",
+          fields: {
+            total: {
+              type: new GraphQLNonNull(GraphQLInt),
+              description: 'Points earned by the current user',
+            },
+            currentLevel: {
+              type: new GraphQLNonNull(GraphQLInt),
+              description: 'Points required for current level',
+            },
+            nextLevel: {
+              type: new GraphQLNonNull(GraphQLInt),
+              description:
+                'Points required for next level. null when there is no next level.',
+            },
           },
-          currentLevel: {
-            type: GraphQLInt,
-            description: 'Points required for current level',
-          },
-          nextLevel: {
-            type: GraphQLInt,
-            description:
-              'Points required for next level. null when there is no next level.',
-          },
-        },
-      }),
-      async (user, arg, context) => {
-        const {
-          totalPoints,
-          currentLevelPoints,
-          nextLevelPoints,
-        } = await context.loaders.userLevelLoader.load(user.id);
+        })
+      ),
+      resolve: async (user, arg, context) => {
+        const { totalPoints, currentLevelPoints, nextLevelPoints } =
+          (await context.loaders.userLevelLoader.load(user.id)) || {};
 
         return {
-          total: totalPoints,
-          currentLevel: currentLevelPoints,
-          nextLevel: nextLevelPoints,
+          total: totalPoints || 0,
+          currentLevel: currentLevelPoints || 0,
+          nextLevel: nextLevelPoints || 1,
         };
-      }
-    ),
+      },
+    },
     createdAt: { type: GraphQLString },
     updatedAt: { type: GraphQLString },
   }),

--- a/src/graphql/models/User.js
+++ b/src/graphql/models/User.js
@@ -63,7 +63,7 @@ const User = new GraphQLObjectType({
       type: GraphQLNonNull(GraphQLInt),
       description: 'Number of article replies this user has given feedbacks',
       resolve: (user, args, context) =>
-        context.loaders.votedArticleReplyFeedbackCountLoader
+        context.loaders.votedArticleReplyCountLoader
           .load(user.id)
           .then(num => num || 0),
     },

--- a/src/graphql/queries/__fixtures__/GetUser.js
+++ b/src/graphql/queries/__fixtures__/GetUser.js
@@ -34,4 +34,13 @@ export default {
       { status: 'NORMAL', appId: 'WEBSITE', userId: 'other-user' },
     ],
   },
+  '/articlereplyfeedbacks/doc/f1': {
+    userId: 'current-user',
+    appId: 'app1',
+    articleId: 'a1',
+    replyId: 'r1',
+    score: 1,
+    createdAt: '2020-03-06T00:00:00.000Z',
+    updatedAt: '2020-04-06T00:00:00.000Z',
+  },
 };

--- a/src/graphql/queries/__tests__/GetUser.js
+++ b/src/graphql/queries/__tests__/GetUser.js
@@ -15,6 +15,7 @@ describe('GetUser', () => {
             name
             email
             repliedArticleCount
+            votedArticleReplyCount
             level
             points {
               total
@@ -33,8 +34,15 @@ describe('GetUser', () => {
         {
           GetUser(id: "test-user") {
             name
-            email
+            email # should be null
+            repliedArticleCount
+            votedArticleReplyCount
             level
+            points {
+              total
+              currentLevel
+              nextLevel
+            }
           }
         }
       `({}, { user: currentUser })

--- a/src/graphql/queries/__tests__/__snapshots__/GetUser.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/GetUser.js.snap
@@ -13,6 +13,7 @@ Object {
         "total": 3,
       },
       "repliedArticleCount": 2,
+      "votedArticleReplyCount": 1,
     },
   },
 }
@@ -25,6 +26,13 @@ Object {
       "email": null,
       "level": 0,
       "name": "test user",
+      "points": Object {
+        "currentLevel": 0,
+        "nextLevel": 1,
+        "total": 0,
+      },
+      "repliedArticleCount": 0,
+      "votedArticleReplyCount": 0,
     },
   },
 }


### PR DESCRIPTION
This PR is for fields required in Profile page UI.

- Figma: https://www.figma.com/file/zpD45j8nqDB2XfA6m2QskO/Cofacts-website?node-id=912%3A385
- Spec: https://g0v.hackmd.io/bbreV0ZqRDarHl4Zt5UpEw

Detail
- Change `points` and `repliedArticleCount` from 'current-user only' to publicly available
- Add `votedArticleReplyCount` to `User`
- Add `GraphQLNonNull` when applicable
