### PR TITLE
Similar replies API and revamp related artitle API

### DIFF
--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -181,7 +181,10 @@ const Article = new GraphQLObjectType({
         },
         ...pagingArgs,
       },
-      async resolve({ id }, { filter = {}, orderBy = [], ...otherParams }) {
+      async resolve(
+        { id },
+        { filter = {}, orderBy = [{ _score: 'DESC' }], ...otherParams }
+      ) {
         const body = {
           query: {
             more_like_this: {

--- a/src/graphql/models/Reply.js
+++ b/src/graphql/models/Reply.js
@@ -6,7 +6,13 @@ import {
   GraphQLID,
 } from 'graphql';
 
-import { filterArticleRepliesByStatus } from 'graphql/util';
+import {
+  filterArticleRepliesByStatus,
+  pagingArgs,
+  getSortArgs,
+  createSortType,
+  createConnectionType,
+} from 'graphql/util';
 import Node from '../interfaces/Node';
 import ReplyTypeEnum from './ReplyTypeEnum';
 import ArticleReplyStatusEnum from './ArticleReplyStatusEnum';
@@ -49,7 +55,88 @@ const Reply = new GraphQLObjectType({
       description:
         'Hyperlinks in reply text or reference. May be empty array if no URLs are included. `null` when hyperlinks are still fetching.',
     },
+    similarReplies: {
+      description:
+        'Replies that has similar text or references of this current reply',
+      args: {
+        orderBy: {
+          type: createSortType('SimilarReplyOrderBy', ['_score', 'createdAt']),
+        },
+        ...pagingArgs,
+      },
+
+      async resolve(
+        { id },
+        { orderBy = [{ _score: 'DESC' }], ...otherParams }
+      ) {
+        const likeQuery = [{ _index: 'replies', _type: 'doc', _id: id }];
+
+        const body = {
+          query: {
+            bool: {
+              should: [
+                {
+                  more_like_this: {
+                    fields: ['text', 'reference'],
+                    like: likeQuery,
+                    min_term_freq: 1,
+                    min_doc_freq: 1,
+                  },
+                },
+                {
+                  nested: {
+                    path: 'hyperlinks',
+                    score_mode: 'sum',
+                    query: {
+                      more_like_this: {
+                        fields: ['hyperlinks.title', 'hyperlinks.summary'],
+                        like: likeQuery,
+                        min_term_freq: 1,
+                        min_doc_freq: 1,
+                      },
+                    },
+                    inner_hits: {
+                      highlight: {
+                        order: 'score',
+                        fields: {
+                          'hyperlinks.title': {
+                            number_of_fragments: 1, // Return only 1 piece highlight text
+                            fragment_size: 200, // word count of highlighted fragment
+                            type: 'plain',
+                          },
+                          'hyperlinks.summary': {
+                            number_of_fragments: 1, // Return only 1 piece highlight text
+                            fragment_size: 200, // word count of highlighted fragment
+                            type: 'plain',
+                          },
+                        },
+                        require_field_match: false,
+                        pre_tags: ['<HIGHLIGHT>'],
+                        post_tags: ['</HIGHLIGHT>'],
+                      },
+                    },
+                  },
+                },
+              ],
+            },
+          },
+          sort: getSortArgs(orderBy),
+          track_scores: true, // required to always populate score
+        };
+
+        return {
+          index: 'replies',
+          type: 'doc',
+          body,
+          ...otherParams,
+        };
+      },
+      // eslint-disable-next-line no-use-before-define
+      type: ReplyConnection,
+    },
   }),
 });
+
+export const ReplyConnection = createConnectionType('ReplyConnection', Reply);
 
 export default Reply;

--- a/src/graphql/models/Reply.js
+++ b/src/graphql/models/Reply.js
@@ -118,6 +118,7 @@ const Reply = new GraphQLObjectType({
                   },
                 },
               ],
+              minimum_should_match: 1,
             },
           },
           sort: getSortArgs(orderBy),

--- a/src/graphql/models/__tests__/User.js
+++ b/src/graphql/models/__tests__/User.js
@@ -9,21 +9,18 @@ jest.mock('lodash', () => ({
 describe('User model', () => {
   describe('pseudo name and avatar generators', () => {
     it('should generate pseudo names for user', () => {
-
       [
-        0,   // adjectives
-        1,   // names
-        2,   // towns
-        3,   // separators
-        4,   // decorators
-        44,  // adjectives
+        0, // adjectives
+        1, // names
+        2, // towns
+        3, // separators
+        4, // decorators
+        44, // adjectives
         890, // names
         349, // towns
-        5,   // separators
-        15    // decorators
-      ].forEach(index =>
-        sample.mockImplementationOnce(ary => ary[index])
-      );
+        5, // separators
+        15, // decorators
+      ].forEach(index => sample.mockImplementationOnce(ary => ary[index]));
 
       expect(generatePseudonym()).toBe(`忠懇的信義區艾達`);
       expect(generatePseudonym()).toBe('㊣來自金城✖一本正經的✖金城武㊣');
@@ -31,29 +28,25 @@ describe('User model', () => {
 
     it('should generate avatars for user', () => {
       [
-        5,  // face
+        5, // face
         12, // hair
-        7,  // body
-        3,  // accessory
-        2,  // facialHair
-        9,  // face
-        0,  // hair
-        2   // body
-      ].forEach(index =>
-        sample.mockImplementationOnce(ary => ary[index])
-      );
+        7, // body
+        3, // accessory
+        2, // facialHair
+        9, // face
+        0, // hair
+        2, // body
+      ].forEach(index => sample.mockImplementationOnce(ary => ary[index]));
       [
-        0,    // with accessory or not
-        0,    // with facialHair or not
-        1,    // to flip image or not
+        0, // with accessory or not
+        0, // with facialHair or not
+        1, // to flip image or not
         0.23, // backgroundColorIndex
-        1,    // with accessory or not
-        1,    // with facialHair or not
-        0,    // to flip image or not
-        0.17  // backgroundColorIndex
-      ].forEach(r =>
-        random.mockReturnValueOnce(r)
-      );
+        1, // with accessory or not
+        1, // with facialHair or not
+        0, // to flip image or not
+        0.17, // backgroundColorIndex
+      ].forEach(r => random.mockReturnValueOnce(r));
 
       expect(generateOpenPeepsAvatar()).toMatchObject({
         accessory: 'None',

--- a/src/graphql/queries/ListReplies.js
+++ b/src/graphql/queries/ListReplies.js
@@ -4,7 +4,6 @@ import client from 'util/client';
 import {
   createFilterType,
   createSortType,
-  createConnectionType,
   getSortArgs,
   pagingArgs,
   timeRangeInput,
@@ -13,7 +12,7 @@ import {
 } from 'graphql/util';
 import scrapUrls from 'util/scrapUrls';
 
-import Reply from 'graphql/models/Reply';
+import { ReplyConnection } from 'graphql/models/Reply';
 import ReplyTypeEnum from 'graphql/models/ReplyTypeEnum';
 
 export default {
@@ -209,5 +208,5 @@ export default {
       ...otherParams,
     };
   },
-  type: createConnectionType('ListReplyConnection', Reply),
+  type: ReplyConnection,
 };

--- a/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
+++ b/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
@@ -92,6 +92,12 @@ export default {
     text: 'bar',
     reference: 'barbar',
     type: 'NOT_ARTICLE',
+    hyperlinks: [
+      {
+        title: 'GG',
+        summary: 'Lorem Ipsum',
+      },
+    ],
   },
   '/replies/doc/bar2': {
     text: 'bar2',
@@ -102,6 +108,24 @@ export default {
     text: 'fofo',
     reference: 'barfofo',
     type: 'NOT_ARTICLE',
+  },
+  '/replies/doc/similar-to-bar': {
+    text: 'bar bar',
+    reference: 'barbar',
+    type: 'NOT_ARTICLE',
+    createdAt: '2015-01-01T12:10:30Z',
+  },
+  '/replies/doc/similar-to-bar2': {
+    text: 'GG',
+    reference: 'GGG',
+    type: 'NOT_ARTICLE',
+    createdAt: '2015-01-02T12:10:30Z',
+    hyperlinks: [
+      {
+        title: 'GG G',
+        summary: 'Lorem Ipsum Ipsum',
+      },
+    ],
   },
   '/replyrequests/doc/articleTest1': {
     articleId: 'foo',

--- a/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
+++ b/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
@@ -57,6 +57,12 @@ export default {
       },
     ],
     normalArticleCategoryCount: 1,
+    hyperlinks: [
+      {
+        title: 'title',
+        summary: 'summary summary',
+      },
+    ],
   },
   '/articles/doc/foo2': {
     text: 'Lorum ipsum Lorum ipsum',
@@ -83,6 +89,12 @@ export default {
     ],
     normalArticleReplyCount: 1,
     references: [{ type: 'LINE' }],
+    hyperlinks: [
+      {
+        title: 'title title',
+        summary: 'summary',
+      },
+    ],
   },
   '/articles/doc/manyRequests': {
     text: 'Popular',

--- a/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
+++ b/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
@@ -303,6 +303,63 @@ describe('GetReplyAndGetArticle', () => {
         `()
       ).toMatchSnapshot();
     });
+    it('similarReplies should work', async () => {
+      // No param
+      //
+      expect(
+        await gql`
+          {
+            GetReply(id: "bar") {
+              similarReplies {
+                edges {
+                  cursor
+                  node {
+                    id
+                  }
+                  score
+                  highlight {
+                    text
+                    reference
+                    hyperlinks {
+                      title
+                      summary
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `()
+      ).toMatchSnapshot('similarReply no-param test');
+
+      // sort
+      //
+      expect(
+        await gql`
+          {
+            GetReply(id: "bar") {
+              similarReplies(orderBy: [{ _score: ASC }]) {
+                edges {
+                  cursor
+                  node {
+                    id
+                  }
+                  score
+                  highlight {
+                    text
+                    reference
+                    hyperlinks {
+                      title
+                      summary
+                    }
+                  }
+                }
+              }
+            }
+          }
+        `()
+      ).toMatchSnapshot('similarReply sorting test');
+    });
   });
 
   afterAll(() => unloadFixtures(fixtures));

--- a/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
+++ b/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
@@ -122,7 +122,14 @@ describe('GetReplyAndGetArticle', () => {
                   cursor
                   node {
                     id
+                  }
+                  highlight {
                     text
+                    reference
+                    hyperlinks {
+                      title
+                      summary
+                    }
                   }
                   score
                 }

--- a/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
@@ -148,12 +148,12 @@ Object {
       "relatedArticles": Object {
         "edges": Array [
           Object {
-            "cursor": "WzAuOTQ4OTIxMywiZm9vMyJd",
+            "cursor": "WzEuMzg5MjM0OCwiZm9vMyJd",
             "node": Object {
               "id": "foo3",
               "text": "Lorum ipsum Lorum ipsum Lorum ipsum",
             },
-            "score": 0.9489213,
+            "score": 1.3892348,
           },
           Object {
             "cursor": "WzAuOTIxMDc0OCwiZm9vMiJd",
@@ -177,18 +177,31 @@ Object {
       "relatedArticles": Object {
         "edges": Array [
           Object {
-            "cursor": "WzAuOTQ4OTIxMywiZm9vMyJd",
+            "cursor": "WzEuMzg5MjM0OCwiZm9vMyJd",
+            "highlight": Object {
+              "hyperlinks": Array [
+                Object {
+                  "summary": "<HIGHLIGHT>summary</HIGHLIGHT>",
+                  "title": "<HIGHLIGHT>title</HIGHLIGHT> <HIGHLIGHT>title</HIGHLIGHT>",
+                },
+              ],
+              "reference": null,
+              "text": "<HIGHLIGHT>Lorum</HIGHLIGHT> <HIGHLIGHT>ipsum</HIGHLIGHT> <HIGHLIGHT>Lorum</HIGHLIGHT> <HIGHLIGHT>ipsum</HIGHLIGHT> <HIGHLIGHT>Lorum</HIGHLIGHT> <HIGHLIGHT>ipsum</HIGHLIGHT>",
+            },
             "node": Object {
               "id": "foo3",
-              "text": "Lorum ipsum Lorum ipsum Lorum ipsum",
             },
-            "score": 0.9489213,
+            "score": 1.3892348,
           },
           Object {
             "cursor": "WzAuOTIxMDc0OCwiZm9vMiJd",
+            "highlight": Object {
+              "hyperlinks": Array [],
+              "reference": null,
+              "text": "<HIGHLIGHT>Lorum</HIGHLIGHT> <HIGHLIGHT>ipsum</HIGHLIGHT> <HIGHLIGHT>Lorum</HIGHLIGHT> <HIGHLIGHT>ipsum</HIGHLIGHT>",
+            },
             "node": Object {
               "id": "foo2",
-              "text": "Lorum ipsum Lorum ipsum",
             },
             "score": 0.9210748,
           },
@@ -214,12 +227,12 @@ Object {
             "score": 0.9210748,
           },
           Object {
-            "cursor": "WzAuOTQ4OTIxMywiZm9vMyJd",
+            "cursor": "WzEuMzg5MjM0OCwiZm9vMyJd",
             "node": Object {
               "id": "foo3",
               "text": "Lorum ipsum Lorum ipsum Lorum ipsum",
             },
-            "score": 0.9489213,
+            "score": 1.3892348,
           },
         ],
       },

--- a/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
@@ -148,7 +148,7 @@ Object {
       "relatedArticles": Object {
         "edges": Array [
           Object {
-            "cursor": "WyJmb28zIl0=",
+            "cursor": "WzAuOTQ4OTIxMywiZm9vMyJd",
             "node": Object {
               "id": "foo3",
               "text": "Lorum ipsum Lorum ipsum Lorum ipsum",
@@ -156,7 +156,7 @@ Object {
             "score": 0.9489213,
           },
           Object {
-            "cursor": "WyJmb28yIl0=",
+            "cursor": "WzAuOTIxMDc0OCwiZm9vMiJd",
             "node": Object {
               "id": "foo2",
               "text": "Lorum ipsum Lorum ipsum",
@@ -177,7 +177,7 @@ Object {
       "relatedArticles": Object {
         "edges": Array [
           Object {
-            "cursor": "WyJmb28zIl0=",
+            "cursor": "WzAuOTQ4OTIxMywiZm9vMyJd",
             "node": Object {
               "id": "foo3",
               "text": "Lorum ipsum Lorum ipsum Lorum ipsum",
@@ -185,7 +185,7 @@ Object {
             "score": 0.9489213,
           },
           Object {
-            "cursor": "WyJmb28yIl0=",
+            "cursor": "WzAuOTIxMDc0OCwiZm9vMiJd",
             "node": Object {
               "id": "foo2",
               "text": "Lorum ipsum Lorum ipsum",
@@ -405,6 +405,90 @@ Object {
       "reference": "barbar",
       "text": "bar",
       "type": "NOT_ARTICLE",
+    },
+  },
+}
+`;
+
+exports[`GetReplyAndGetArticle GetReply similarReplies should work: similarReply no-param test 1`] = `
+Object {
+  "data": Object {
+    "GetReply": Object {
+      "similarReplies": Object {
+        "edges": Array [
+          Object {
+            "cursor": "WzEuODg5MTY5Mywic2ltaWxhci10by1iYXIiXQ==",
+            "highlight": Object {
+              "hyperlinks": Array [],
+              "reference": "<HIGHLIGHT>barbar</HIGHLIGHT>",
+              "text": "<HIGHLIGHT>bar</HIGHLIGHT> <HIGHLIGHT>bar</HIGHLIGHT>",
+            },
+            "node": Object {
+              "id": "similar-to-bar",
+            },
+            "score": 1.8891693,
+          },
+          Object {
+            "cursor": "WzAuNTY2MzE3Miwic2ltaWxhci10by1iYXIyIl0=",
+            "highlight": Object {
+              "hyperlinks": Array [
+                Object {
+                  "summary": "<HIGHLIGHT>Lorem</HIGHLIGHT> <HIGHLIGHT>Ipsum</HIGHLIGHT> <HIGHLIGHT>Ipsum</HIGHLIGHT>",
+                  "title": "<HIGHLIGHT>GG</HIGHLIGHT> G",
+                },
+              ],
+              "reference": null,
+              "text": null,
+            },
+            "node": Object {
+              "id": "similar-to-bar2",
+            },
+            "score": 0.5663172,
+          },
+        ],
+      },
+    },
+  },
+}
+`;
+
+exports[`GetReplyAndGetArticle GetReply similarReplies should work: similarReply sorting test 1`] = `
+Object {
+  "data": Object {
+    "GetReply": Object {
+      "similarReplies": Object {
+        "edges": Array [
+          Object {
+            "cursor": "WzAuNTY2MzE3Miwic2ltaWxhci10by1iYXIyIl0=",
+            "highlight": Object {
+              "hyperlinks": Array [
+                Object {
+                  "summary": "<HIGHLIGHT>Lorem</HIGHLIGHT> <HIGHLIGHT>Ipsum</HIGHLIGHT> <HIGHLIGHT>Ipsum</HIGHLIGHT>",
+                  "title": "<HIGHLIGHT>GG</HIGHLIGHT> G",
+                },
+              ],
+              "reference": null,
+              "text": null,
+            },
+            "node": Object {
+              "id": "similar-to-bar2",
+            },
+            "score": 0.5663172,
+          },
+          Object {
+            "cursor": "WzEuODg5MTY5Mywic2ltaWxhci10by1iYXIiXQ==",
+            "highlight": Object {
+              "hyperlinks": Array [],
+              "reference": "<HIGHLIGHT>barbar</HIGHLIGHT>",
+              "text": "<HIGHLIGHT>bar</HIGHLIGHT> <HIGHLIGHT>bar</HIGHLIGHT>",
+            },
+            "node": Object {
+              "id": "similar-to-bar",
+            },
+            "score": 1.8891693,
+          },
+        ],
+      },
     },
   },
 }


### PR DESCRIPTION
This PR adds `similarReplies` to `Reply` object type to display [similar reply section in reply page](https://www.figma.com/file/zpD45j8nqDB2XfA6m2QskO/Cofacts-website?node-id=894%3A85). Given that replies are often copied over to another, this function should be useful when finding duplicated replies.

Several refactors to `Article` object type's `relatedArticles` are also added, including:
- Default to sort by score (high to low)
- Add hyperlink title / summary matching
- Test highlights are generated in unit tests