### PR TITLE
Script to remove an article reply on production

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ $ node_modules/.bin/babel-node src/scripts/fetchStatsFromGA.js
 ### Removing article-reply from database
 -  To set an article-reply to deleted state on production, run:
 ```
-$ node build/scripts/removeArticleReply.js -- --userId=<userId> --articleId=<articleId> --replyId=<replyId>
+$ node build/scripts/removeArticleReply.js --userId=<userId> --articleId=<articleId> --replyId=<replyId>
 ```
 
 -  For more options, run the above script with `--help` or see the file level comments.

--- a/README.md
+++ b/README.md
@@ -165,6 +165,14 @@ $ node_modules/.bin/babel-node src/scripts/fetchStatsFromGA.js
 
 -  For more options, run the above script with `--help` or see the file level comments.
 
+### Removing article-reply from database
+-  To set an article-reply to deleted state on production, run:
+```
+$ node build/scripts/removeArticleReply.js -- --userId=<userId> --articleId=<articleId> --replyId=<replyId>
+```
+
+-  For more options, run the above script with `--help` or see the file level comments.
+
 
 ## One-off migration scripts
 
@@ -189,12 +197,12 @@ Then at project root, run:
 $ node_modules/.bin/babel-node src/scripts/migrations/createBackendUsers.js
 ```
 
-This script would scan for all the user references in `analytics`, `articlecategoryfeedbacks`, `articlereplyfeedbacks`, 
+This script would scan for all the user references in `analytics`, `articlecategoryfeedbacks`, `articlereplyfeedbacks`,
 `articles`, `replies`, `replyrequests`, create users for those that are not already in db and updates all the docs.
 See the comments at the top of the script for how users are referenced in each doc.
 
 
-## Troubleshooting 
+## Troubleshooting
 
 ### Failed to load gRPC binary on Mac
 

--- a/src/graphql/mutations/UpdateArticleReplyStatus.js
+++ b/src/graphql/mutations/UpdateArticleReplyStatus.js
@@ -3,6 +3,80 @@ import client from 'util/client';
 import ArticleReply from 'graphql/models/ArticleReply';
 import ArticleReplyStatusEnum from 'graphql/models/ArticleReplyStatusEnum';
 
+/**
+ * @param {object} arg
+ * @param {string} arg.articleId
+ * @param {string} arg.replyId
+ * @param {string} arg.userId
+ * @param {string} arg.appId
+ * @param {string} arg.status
+ *
+ * @returns {ArticleReply[]} list of article replies after delete
+ */
+export async function updateArticleReplyStatus({
+  articleId,
+  replyId,
+  userId,
+  appId,
+  status,
+}) {
+  const {
+    body: {
+      result,
+      get: { _source },
+    },
+  } = await client.update({
+    index: 'articles',
+    type: 'doc',
+    id: articleId,
+    body: {
+      script: {
+        source: `
+          int idx = 0;
+          int replyCount = ctx._source.articleReplies.size();
+          for(; idx < replyCount; idx += 1) {
+            HashMap articleReply = ctx._source.articleReplies.get(idx);
+            if(
+              articleReply.get('replyId').equals(params.replyId) &&
+              articleReply.get('userId').equals(params.userId) &&
+              articleReply.get('appId').equals(params.appId)
+            ) {
+              break;
+            }
+          }
+
+          if( idx === replyCount ) {
+            ctx.op = 'none';
+          } else {
+            ctx._source.articleReplies.get(idx).put('status', params.status);
+            ctx._source.articleReplies.get(idx).put('updatedAt', params.updatedAt);
+            ctx._source.normalArticleReplyCount = ctx._source.articleReplies.stream().filter(
+              ar -> ar.get('status').equals('NORMAL')
+            ).count();
+          }
+        `,
+        params: {
+          replyId,
+          userId,
+          appId,
+          status,
+          updatedAt: new Date().toISOString(),
+        },
+        lang: 'painless',
+      },
+      _source: ['articleReplies.*'],
+    },
+  });
+
+  if (result === 'noop') {
+    throw new Error(
+      `Cannot change status for articleReply(articleId=${articleId}, replyId=${replyId})`
+    );
+  }
+
+  return _source.articleReplies;
+}
+
 export default {
   type: new GraphQLList(ArticleReply),
   description: 'Change status of specified articleReplies',
@@ -14,61 +88,15 @@ export default {
     },
   },
   async resolve(rootValue, { articleId, replyId, status }, { userId, appId }) {
-    const {
-      body: {
-        result,
-        get: { _source },
-      },
-    } = await client.update({
-      index: 'articles',
-      type: 'doc',
-      id: articleId,
-      body: {
-        script: {
-          source: `
-            int idx = 0;
-            int replyCount = ctx._source.articleReplies.size();
-            for(; idx < replyCount; idx += 1) {
-              HashMap articleReply = ctx._source.articleReplies.get(idx);
-              if(
-                articleReply.get('replyId').equals(params.replyId) &&
-                articleReply.get('userId').equals(params.userId) &&
-                articleReply.get('appId').equals(params.appId)
-              ) {
-                break;
-              }
-            }
-
-            if( idx === replyCount ) {
-              ctx.op = 'none';
-            } else {
-              ctx._source.articleReplies.get(idx).put('status', params.status);
-              ctx._source.articleReplies.get(idx).put('updatedAt', params.updatedAt);
-              ctx._source.normalArticleReplyCount = ctx._source.articleReplies.stream().filter(
-                ar -> ar.get('status').equals('NORMAL')
-              ).count();
-            }
-          `,
-          params: {
-            replyId,
-            userId,
-            appId,
-            status,
-            updatedAt: new Date().toISOString(),
-          },
-          lang: 'painless',
-        },
-        _source: ['articleReplies.*'],
-      },
+    const articleReplies = await updateArticleReplyStatus({
+      articleId,
+      replyId,
+      userId,
+      appId,
+      status,
     });
 
-    if (result === 'noop') {
-      throw new Error(
-        `Cannot change status for articleReply(articleId=${articleId}, replyId=${replyId})`
-      );
-    }
-
     // When returning, insert articleId so that ArticleReply object type can resolve article.
-    return _source.articleReplies.map(ar => ({ ...ar, articleId }));
+    return articleReplies.map(ar => ({ ...ar, articleId }));
   },
 };

--- a/src/scripts/__fixtures__/removeArticleReply.js
+++ b/src/scripts/__fixtures__/removeArticleReply.js
@@ -1,0 +1,25 @@
+export default {
+  '/articles/doc/article1': {
+    articleReplies: [
+      {
+        status: 'NORMAL',
+        appId: 'WEBSITE',
+        userId: 'current-user',
+        replyId: 'foo',
+      },
+      {
+        status: 'NORMAL',
+        appId: 'WEBSITE',
+        userId: 'current-user',
+        replyId: 'bar',
+      },
+      {
+        status: 'NORMAL',
+        appId: 'WEBSITE',
+        userId: 'other-user',
+        replyId: 'foo2',
+      },
+    ],
+    normalArticleReplyCount: 3,
+  },
+};

--- a/src/scripts/__tests__/removeArticleReply.js
+++ b/src/scripts/__tests__/removeArticleReply.js
@@ -1,0 +1,96 @@
+import MockDate from 'mockdate';
+import { loadFixtures, unloadFixtures } from 'util/fixtures';
+import client from 'util/client';
+import removeArticleReply from '../removeArticleReply';
+import fixtures from '../__fixtures__/removeArticleReply';
+
+const FIXED_DATE = 612921600000;
+
+beforeEach(() => loadFixtures(fixtures));
+afterEach(() => unloadFixtures(fixtures));
+
+it('should block invalid usage', async () => {
+  await expect(removeArticleReply()).rejects.toMatchInlineSnapshot(
+    `[Error: Please provide all of articleId, replyId and userId]`
+  );
+  await expect(
+    removeArticleReply({
+      userId: 'current-user',
+      articleId: 'article1' /* replyId missing */,
+    })
+  ).rejects.toMatchInlineSnapshot(
+    `[Error: Please provide all of articleId, replyId and userId]`
+  );
+});
+
+it('should abort when article or reply ID is wrong', async () => {
+  await expect(
+    removeArticleReply({
+      userId: 'no-such-user',
+      articleId: 'article1',
+      replyId: 'foo',
+    })
+  ).rejects.toMatchInlineSnapshot(
+    `[Error: Cannot change status for articleReply(articleId=article1, replyId=foo)]`
+  );
+  await expect(
+    removeArticleReply({
+      userId: 'current-user',
+      articleId: 'no-such-article',
+      replyId: 'foo',
+    })
+  ).rejects.toMatchInlineSnapshot(
+    `[ResponseError: document_missing_exception]`
+  );
+  await expect(
+    removeArticleReply({
+      userId: 'current-user',
+      articleId: 'article1',
+      replyId: 'no-such-reply',
+    })
+  ).rejects.toMatchInlineSnapshot(
+    `[Error: Cannot change status for articleReply(articleId=article1, replyId=no-such-reply)]`
+  );
+});
+
+it('successfully deletes article-reply and updates normalArticleReplyCount', async () => {
+  MockDate.set(FIXED_DATE);
+  const result = await removeArticleReply({
+    userId: 'current-user',
+    articleId: 'article1',
+    replyId: 'foo',
+  });
+  MockDate.reset();
+
+  expect(result).toMatchInlineSnapshot(`
+Array [
+  Object {
+    "appId": "WEBSITE",
+    "replyId": "foo",
+    "status": "DELETED",
+    "updatedAt": "1989-06-04T00:00:00.000Z",
+    "userId": "current-user",
+  },
+  Object {
+    "appId": "WEBSITE",
+    "replyId": "bar",
+    "status": "NORMAL",
+    "userId": "current-user",
+  },
+  Object {
+    "appId": "WEBSITE",
+    "replyId": "foo2",
+    "status": "NORMAL",
+    "userId": "other-user",
+  },
+]
+`);
+  const {
+    body: { _source },
+  } = await client.get({
+    index: 'articles',
+    type: 'doc',
+    id: 'article1',
+  });
+  expect(_source.normalArticleReplyCount).toBe(2);
+});

--- a/src/scripts/removeArticleReply.js
+++ b/src/scripts/removeArticleReply.js
@@ -1,0 +1,49 @@
+// eslint-disable no-console
+/*
+  A script that deletes an article reply
+*/
+
+import { updateArticleReplyStatus } from 'graphql/mutations/UpdateArticleReplyStatus';
+import yargs from 'yargs';
+
+async function main({ articleId, replyId, userId }) {
+  if (!articleId || !replyId || !userId)
+    throw new Error('Please provide all of articleId, replyId and userId');
+
+  return updateArticleReplyStatus({
+    articleId,
+    replyId,
+    userId,
+    appId: 'WEBSITE',
+    status: 'DELETED',
+  });
+}
+
+export default main;
+
+if (require.main === module) {
+  const argv = yargs
+    .options({
+      userId: {
+        alias: 'u',
+        description: 'User ID of the reply.',
+        type: 'string',
+        demandOption: true,
+      },
+      articleId: {
+        alias: 'a',
+        description: 'Article ID of the articleReply',
+        type: 'string',
+        demandOption: true,
+      },
+      replyId: {
+        alias: 'r',
+        description: 'Reply ID of the articleReply',
+        type: 'string',
+        demandOption: true,
+      },
+    })
+    .help('help').argv;
+
+  main(argv).catch(console.error);
+}

--- a/src/scripts/removeArticleReply.js
+++ b/src/scripts/removeArticleReply.js
@@ -6,7 +6,7 @@
 import { updateArticleReplyStatus } from 'graphql/mutations/UpdateArticleReplyStatus';
 import yargs from 'yargs';
 
-async function main({ articleId, replyId, userId }) {
+async function main({ articleId, replyId, userId } = {}) {
   if (!articleId || !replyId || !userId)
     throw new Error('Please provide all of articleId, replyId and userId');
 


### PR DESCRIPTION
Due to [recent spamming](https://www.facebook.com/groups/cofacts/permalink/2866149510283526/),
we are adding a script that:
- Marks an article-reply as deleted on user's behave
- Updates `normalArticleReplyCount`

The script is tested on staging.