### PR TITLE
[Trivial] expose user.appId for all users & all apps

### DIFF
--- a/src/graphql/models/User.js
+++ b/src/graphql/models/User.js
@@ -61,8 +61,7 @@ const User = new GraphQLObjectType({
       user => getAvailableAvatarTypes(user)
     ),
 
-    // TODO: also enable these two fields for requests from the same app?
-    appId: currentUserOnlyField(GraphQLString),
+    appId: { type: GraphQLString },
     appUserId: currentUserOnlyField(GraphQLString),
 
     facebookId: currentUserOnlyField(GraphQLString),
@@ -149,7 +148,7 @@ export const userFieldResolver = async (
     if (user) return user;
   }
 
-  /* TODO: some unit tests are depending on this code block, need to clean up those tests and then 
+  /* TODO: some unit tests are depending on this code block, need to clean up those tests and then
      remove the following lines, and the corresponding unit test. */
 
   // If the user comes from the same client as the root document, return the user id.


### PR DESCRIPTION
In the user profile page for LINE bot users, I want to tell site visitors that this user is from LINE and its username / avatar is randomly generated. Therefore, I would like to expose user's `appId`.

Currently I cannot think of reasons why we kept it for current user. No concern is documented in [the design document](https://g0v.hackmd.io/ZcoUOX_-RQSkJyl5xz4_Zg#%E6%96%B9%E5%90%91-2-%E9%87%9D%E5%B0%8D%E6%AF%8F%E5%80%8B-backend-user-%E9%83%BD%E7%94%A2%E7%94%9F%E4%B8%80%E5%80%8B-user-document) either. This PR removes the restriction.