### PR TITLE
Redirect user to domains in RUMORS_SITE_REDIRECT_ORIGIN to fix login issue

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -12,13 +12,17 @@ ROLLBAR_ENV=localhost
 HTTP_HEADER_APP_ID=x-app-id
 HTTP_HEADER_APP_SECRET=x-app-secret
 
-# Official web clients.
-# Use comma to separate all site origins.
-# After logging-in, it will always redirect user to the first domain.
-# Please make sure the first domain matches PUBLIC_API_URL in rumors-site
+# Official web clients. Use comma to separate all site origins.
+RUMORS_SITE_CORS_ORIGIN=http://localhost:3000
+
+# Websites to redirect back to. Use comma to separate all site origins.
+# After logging-in, it will always redirect user to domains specified here.
+# If the request is coming from other domains, it will be redirected to the first origin here.
+#
+# Please make sure the domain is the "same site" as PUBLIC_API_URL in rumors-site
 # so that login cookies can be picked up when rumors-site make requests to this API server.
 #
-RUMORS_SITE_CORS_ORIGIN=http://localhost:3000
+RUMORS_SITE_REDIRECT_ORIGIN=http://localhost:3000
 
 # Official LINE clients
 RUMORS_LINE_BOT_CORS_ORIGIN=http://localhost:5001

--- a/.env.sample
+++ b/.env.sample
@@ -61,7 +61,7 @@ GA_WEB_VIEW_ID=GA_WEB_VIEW_ID
 GA_LINE_VIEW_ID=GA_LINE_VIEW_ID
 
 # URL to URL resolver microservice (http://github.com/cofacts/url-resolver)
-URL_RESOLVER_URL=http://localhost:4000
+URL_RESOLVER_URL=localhost:4000
 
 # Apollo engine. When not given, disables Apollo Engine introspection
 ENGINE_API_KEY=

--- a/.env.sample
+++ b/.env.sample
@@ -12,8 +12,13 @@ ROLLBAR_ENV=localhost
 HTTP_HEADER_APP_ID=x-app-id
 HTTP_HEADER_APP_SECRET=x-app-secret
 
-# official web clients
+# Official web clients
+# Used when redirecting the user back
+# Must to be in the "same-site" as rumors-site
+# Ref: https://web.dev/samesite-cookies-explained/
 RUMORS_SITE_CORS_ORIGIN=http://localhost:3000
+
+# Official LINE clients
 RUMORS_LINE_BOT_CORS_ORIGIN=http://localhost:5001
 
 # official line bot client

--- a/.env.sample
+++ b/.env.sample
@@ -12,10 +12,12 @@ ROLLBAR_ENV=localhost
 HTTP_HEADER_APP_ID=x-app-id
 HTTP_HEADER_APP_SECRET=x-app-secret
 
-# Official web clients
-# Used when redirecting the user back
-# Must to be in the "same-site" as rumors-site
-# Ref: https://web.dev/samesite-cookies-explained/
+# Official web clients.
+# Use comma to separate all site origins.
+# After logging-in, it will always redirect user to the first domain.
+# Please make sure the first domain matches PUBLIC_API_URL in rumors-site
+# so that login cookies can be picked up when rumors-site make requests to this API server.
+#
 RUMORS_SITE_CORS_ORIGIN=http://localhost:3000
 
 # Official LINE clients

--- a/src/auth.js
+++ b/src/auth.js
@@ -221,13 +221,18 @@ export const authRouter = Router()
       ctx.session.appId === 'RUMORS_SITE' ||
       ctx.session.appId === 'DEVELOPMENT_FRONTEND'
     ) {
-      const allowedOrigins = process.env.RUMORS_SITE_CORS_ORIGIN.split(',');
-      basePath = allowedOrigins.find(o => o === ctx.session.origin);
+      basePath = process.env.RUMORS_SITE_CORS_ORIGIN;
     }
 
     // TODO: Get basePath from DB for other client apps
+    try {
+      ctx.redirect(new URL(ctx.session.redirect, basePath).href);
+    } catch (err) {
+      err.status = 400;
+      err.expose = true;
+      throw err;
+    }
 
-    ctx.redirect(new URL(ctx.session.redirect, basePath).href);
     // eslint-disable-next-line require-atomic-updates
     ctx.session.appId = undefined;
     // eslint-disable-next-line require-atomic-updates

--- a/src/auth.js
+++ b/src/auth.js
@@ -221,7 +221,11 @@ export const authRouter = Router()
       ctx.session.appId === 'RUMORS_SITE' ||
       ctx.session.appId === 'DEVELOPMENT_FRONTEND'
     ) {
-      basePath = process.env.RUMORS_SITE_CORS_ORIGIN;
+      const allowedOrigins = process.env.RUMORS_SITE_CORS_ORIGIN.split(',');
+
+      // Always use the first origin.
+      // Please make sure this matches PUBLIC_API_URL in rumors-site
+      basePath = allowedOrigins[0];
     }
 
     // TODO: Get basePath from DB for other client apps

--- a/src/auth.js
+++ b/src/auth.js
@@ -221,11 +221,12 @@ export const authRouter = Router()
       ctx.session.appId === 'RUMORS_SITE' ||
       ctx.session.appId === 'DEVELOPMENT_FRONTEND'
     ) {
-      const allowedOrigins = process.env.RUMORS_SITE_CORS_ORIGIN.split(',');
+      const validOrigins = (
+        process.env.RUMORS_SITE_REDIRECT_ORIGIN || ''
+      ).split(',');
 
-      // Always use the first origin.
-      // Please make sure this matches PUBLIC_API_URL in rumors-site
-      basePath = allowedOrigins[0];
+      basePath =
+        validOrigins.find(o => o === ctx.session.origin) || validOrigins[0];
     }
 
     // TODO: Get basePath from DB for other client apps


### PR DESCRIPTION
This PR fixes #250 

## Current situation

On Mac & iOS safari, users cannot login when they visit https://cofacts.org.

This is because the current login mechanism will write cookie to https://cofacts-api.g0v.tw.

Even though https://cofacts-api.g0v.tw have CORS enabled and also uses `sames-site: lax`, it is possibly that [browsers *are* blocking all third-party cookies](https://www.adexchanger.com/privacy/chrome-is-killing-cookies-but-samesite-still-needs-to-be-updated/) anyway. 

## What this PR do

We redirect users to domains listed in `RUMORS_SITE_REDIRECT_ORIGIN`.

After we apply corresponding changes in rumors-deploy ( cofacts/rumors-deploy#18 ), we can always redirect users to `https://cofacts.tw` or `https://en.cofacts.tw`, depending on which site the user is visiting.

We also have better error handing for URL concatenation errors.
Since the website always connects to `https://api.cofacts.tw`, and `https://cofacts.tw` & `https://api.cofacts.tw` are considered [same-site](https://web.dev/samesite-cookies-explained/#explicitly-state-cookie-usage-with-the-samesite-attribute), the browser can pickup the login session cookie and shows as logged-in.