### PR TITLE
Validate slug and block invalid slug

### DIFF
--- a/src/graphql/models/SlugErrorEnum.js
+++ b/src/graphql/models/SlugErrorEnum.js
@@ -1,0 +1,32 @@
+import { GraphQLEnumType } from 'graphql';
+
+export const errors = {
+  EMPTY: 'EMPTY',
+  NOT_TRIMMED: 'NOT_TRIMMED',
+  HAS_URI_COMPONENT: 'HAS_URI_COMPONENT',
+  TAKEN: 'TAKEN',
+};
+
+export default new GraphQLEnumType({
+  name: 'SlugErrorEnum',
+  description: 'Slug of canot',
+  values: {
+    [errors.EMPTY]: {
+      value: errors.EMPTY,
+      description: 'Slug is empty',
+    },
+    [errors.NOT_TRIMMED]: {
+      value: errors.NOT_TRIMMED,
+      description: 'Slug have leading or trailing spaces or line ends',
+    },
+    [errors.HAS_URI_COMPONENT]: {
+      value: errors.HAS_URI_COMPONENT,
+      description:
+        'Slug has URI component inside, which can be misleading to browsers',
+    },
+    [errors.TAKEN]: {
+      value: errors.TAKEN,
+      description: 'Slug has already been taken by someone else',
+    },
+  },
+});

--- a/src/graphql/mutations/UpdateUser.js
+++ b/src/graphql/mutations/UpdateUser.js
@@ -3,6 +3,8 @@ import client from 'util/client';
 import User from 'graphql/models/User';
 import { omit, omitBy } from 'lodash';
 import { AvatarTypes } from 'util/user';
+
+import { assertSlugIsValid } from 'graphql/queries/ValidateSlug';
 import AvatarTypeEnum from 'graphql/models/AvatarTypeEnum';
 
 export default {
@@ -37,21 +39,7 @@ export default {
 
     // Ensure uniqueness of slug
     if (slug !== undefined) {
-      const {
-        body: { count },
-      } = await client.count({
-        index: 'users',
-        type: 'doc',
-        body: {
-          query: {
-            bool: {
-              must: [{ term: { slug } }],
-              must_not: [{ ids: { values: [userId] } }],
-            },
-          },
-        },
-      });
-      if (count > 0) throw new Error(`Slug already taken`);
+      assertSlugIsValid(slug, userId);
     }
 
     if (avatarType && avatarType !== AvatarTypes.OpenPeeps)

--- a/src/graphql/mutations/UpdateUser.js
+++ b/src/graphql/mutations/UpdateUser.js
@@ -64,6 +64,7 @@ export default {
       },
     });
 
+    /* istanbul ignore if */
     if (result === 'noop') {
       throw new Error(`Cannot update user`);
     }

--- a/src/graphql/mutations/UpdateUser.js
+++ b/src/graphql/mutations/UpdateUser.js
@@ -39,7 +39,11 @@ export default {
 
     // Ensure uniqueness of slug
     if (slug !== undefined) {
-      assertSlugIsValid(slug, userId);
+      try {
+        await assertSlugIsValid(slug, userId);
+      } catch (e) {
+        throw new Error(`Invalid slug: ${e}`);
+      }
     }
 
     if (avatarType && avatarType !== AvatarTypes.OpenPeeps)

--- a/src/graphql/mutations/__tests__/__snapshots__/UpdateUser.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/UpdateUser.js.snap
@@ -2,7 +2,7 @@
 
 exports[`UpdateUser cannot set duplicated slug 1`] = `
 Array [
-  [GraphQLError: Slug already taken],
+  [GraphQLError: Invalid slug: TAKEN],
 ]
 `;
 
@@ -15,6 +15,46 @@ Object {
   "name": "test user 1",
   "slug": "test-user-1",
   "updatedAt": "2020-01-01T00:00:10.000Z",
+}
+`;
+
+exports[`UpdateUser should not set unsupported fields 1`] = `
+Array [
+  [GraphQLError: Unknown argument "email" on field "Mutation.UpdateUser".],
+]
+`;
+
+exports[`UpdateUser should not set unsupported fields 2`] = `
+Object {
+  "avatarType": "Gravatar",
+  "bio": "blahblahblah",
+  "email": "user1@example.com",
+  "facebookId": "fbid123",
+  "githubId": "githubId123",
+  "id": "testUser1",
+  "name": "new name",
+  "slug": "test-user-3",
+  "updatedAt": "2020-01-01T00:00:30.000Z",
+}
+`;
+
+exports[`UpdateUser should not unset fields 1`] = `
+Array [
+  [GraphQLError: There's nothing to update],
+]
+`;
+
+exports[`UpdateUser should not unset fields 2`] = `
+Object {
+  "avatarType": "Gravatar",
+  "bio": "blahblahblah",
+  "email": "user1@example.com",
+  "facebookId": "fbid123",
+  "githubId": "githubId123",
+  "id": "testUser1",
+  "name": "new name",
+  "slug": "test-user-3",
+  "updatedAt": "2020-01-01T00:00:30.000Z",
 }
 `;
 
@@ -75,46 +115,6 @@ Object {
     "slug": "test-user-3",
     "updatedAt": "2020-01-01T00:01:00.000Z",
   },
-}
-`;
-
-exports[`UpdateUser should not set unsupported fields 1`] = `
-Array [
-  [GraphQLError: Unknown argument "email" on field "Mutation.UpdateUser".],
-]
-`;
-
-exports[`UpdateUser should not set unsupported fields 2`] = `
-Object {
-  "avatarType": "Gravatar",
-  "bio": "blahblahblah",
-  "email": "user1@example.com",
-  "facebookId": "fbid123",
-  "githubId": "githubId123",
-  "id": "testUser1",
-  "name": "new name",
-  "slug": "test-user-3",
-  "updatedAt": "2020-01-01T00:00:30.000Z",
-}
-`;
-
-exports[`UpdateUser should not unset fields 1`] = `
-Array [
-  [GraphQLError: There's nothing to update],
-]
-`;
-
-exports[`UpdateUser should not unset fields 2`] = `
-Object {
-  "avatarType": "Gravatar",
-  "bio": "blahblahblah",
-  "email": "user1@example.com",
-  "facebookId": "fbid123",
-  "githubId": "githubId123",
-  "id": "testUser1",
-  "name": "new name",
-  "slug": "test-user-3",
-  "updatedAt": "2020-01-01T00:00:30.000Z",
 }
 `;
 

--- a/src/graphql/queries/ValidateSlug.js
+++ b/src/graphql/queries/ValidateSlug.js
@@ -66,6 +66,7 @@ export default {
     try {
       await assertSlugIsValid(slug, userId);
     } catch (e) {
+      /* istanbul ignore else */
       if (e in errors) {
         return {
           success: false,

--- a/src/graphql/queries/ValidateSlug.js
+++ b/src/graphql/queries/ValidateSlug.js
@@ -1,0 +1,78 @@
+import {
+  GraphQLObjectType,
+  GraphQLNonNull,
+  GraphQLString,
+  GraphQLBoolean,
+} from 'graphql';
+
+import client from 'util/client';
+import SlugErrorEnum, { errors } from 'graphql/models/SlugErrorEnum';
+
+/**
+ * Throws error if slug is not valid
+ *
+ * @param {string} slug - The string to check as slug
+ * @param {string} userId - The user that want to use this slug
+ */
+export async function assertSlugIsValid(slug, userId) {
+  const trimmedSlug = slug.trim();
+
+  if (!trimmedSlug) {
+    throw errors.EMPTY;
+  }
+
+  if (slug !== trimmedSlug) {
+    throw errors.NOT_TRIMMED;
+  }
+
+  if (encodeURI(slug) !== encodeURIComponent(slug)) {
+    throw errors.HAS_URI_COMPONENT;
+  }
+
+  const {
+    body: { count },
+  } = await client.count({
+    index: 'users',
+    type: 'doc',
+    body: {
+      query: {
+        bool: {
+          must: [{ term: { slug } }],
+          must_not: [{ ids: { values: [userId] } }],
+        },
+      },
+    },
+  });
+
+  if (count > 0) throw errors.TAKEN;
+}
+
+export default {
+  args: {
+    slug: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+  },
+  type: new GraphQLObjectType({
+    name: 'ValidationResult',
+    fields: {
+      success: { type: new GraphQLNonNull(GraphQLBoolean) },
+      error: { type: SlugErrorEnum },
+    },
+  }),
+  async resolve(rootValue, { slug }, { userId }) {
+    try {
+      assertSlugIsValid(slug, userId);
+    } catch (e) {
+      if (e in errors) {
+        return {
+          success: false,
+          error: e,
+        };
+      }
+
+      // Re-throw if unexpected errors
+      throw e;
+    }
+  },
+};

--- a/src/graphql/queries/ValidateSlug.js
+++ b/src/graphql/queries/ValidateSlug.js
@@ -5,6 +5,7 @@ import {
   GraphQLBoolean,
 } from 'graphql';
 
+import { assertUser } from 'util/user';
 import client from 'util/client';
 import SlugErrorEnum, { errors } from 'graphql/models/SlugErrorEnum';
 
@@ -60,9 +61,10 @@ export default {
       error: { type: SlugErrorEnum },
     },
   }),
-  async resolve(rootValue, { slug }, { userId }) {
+  async resolve(rootValue, { slug }, { userId, appId }) {
+    assertUser({ userId, appId });
     try {
-      assertSlugIsValid(slug, userId);
+      await assertSlugIsValid(slug, userId);
     } catch (e) {
       if (e in errors) {
         return {
@@ -71,8 +73,12 @@ export default {
         };
       }
 
-      // Re-throw if unexpected errors
+      // Re-throw unexpected errors
       throw e;
     }
+
+    return {
+      success: true,
+    };
   },
 };

--- a/src/graphql/queries/__fixtures__/ValidateSlug.js
+++ b/src/graphql/queries/__fixtures__/ValidateSlug.js
@@ -1,0 +1,10 @@
+export default {
+  '/users/doc/test-user': {
+    id: 'test-user',
+    slug: 'taken',
+    name: 'test user',
+    email: 'secret@secret.com',
+    avatarType: 'Facebook',
+    facebookId: 123456,
+  },
+};

--- a/src/graphql/queries/__tests__/ValidateSlug.js
+++ b/src/graphql/queries/__tests__/ValidateSlug.js
@@ -1,0 +1,144 @@
+import fixtures from '../__fixtures__/ValidateSlug';
+import { loadFixtures, unloadFixtures } from 'util/fixtures';
+import gql from 'util/GraphQL';
+
+import { assertSlugIsValid } from '../ValidateSlug';
+import { errors } from 'graphql/models/SlugErrorEnum';
+
+describe('assertSlugIsValid', () => {
+  beforeAll(() => loadFixtures(fixtures));
+  afterAll(() => unloadFixtures(fixtures));
+
+  it('returns for valid slugs', async () => {
+    await expect(assertSlugIsValid('valid', 'other-user')).resolves.toEqual(
+      undefined
+    );
+    await expect(assertSlugIsValid('space ok', 'other-user')).resolves.toEqual(
+      undefined
+    );
+    await expect(assertSlugIsValid('正確', 'other-user')).resolves.toEqual(
+      undefined
+    );
+    await expect(assertSlugIsValid('👌', 'other-user')).resolves.toEqual(
+      undefined
+    );
+  });
+
+  it('does not throw error if the slug is taken by the user themselves', async () => {
+    await expect(assertSlugIsValid('taken', 'test-user')).resolves.toEqual(
+      undefined
+    );
+  });
+
+  it('throws slug error', async () => {
+    await expect(assertSlugIsValid('    ', 'other-user')).rejects.toEqual(
+      errors.EMPTY
+    );
+
+    await expect(
+      assertSlugIsValid('    leading space', 'other-user')
+    ).rejects.toEqual(errors.NOT_TRIMMED);
+    await expect(
+      assertSlugIsValid('trailing space   ', 'other-user')
+    ).rejects.toEqual(errors.NOT_TRIMMED);
+
+    await expect(assertSlugIsValid(':3', 'other-user')).rejects.toEqual(
+      errors.HAS_URI_COMPONENT
+    ); // :
+    await expect(assertSlugIsValid('1/2', 'other-user')).rejects.toEqual(
+      errors.HAS_URI_COMPONENT
+    ); // /
+
+    await expect(assertSlugIsValid('taken', 'other-user')).rejects.toEqual(
+      errors.TAKEN
+    );
+  });
+});
+
+describe('ValidateSlug', () => {
+  beforeAll(() => loadFixtures(fixtures));
+  afterAll(() => unloadFixtures(fixtures));
+
+  it('rejects anonymous user', async () => {
+    await expect(
+      gql`
+        {
+          ValidateSlug(slug: "foo") {
+            success
+            error
+          }
+        }
+      `(
+        {},
+        {
+          appId: 'some-app',
+        }
+      )
+    ).resolves.toMatchInlineSnapshot(`
+            Object {
+              "data": Object {
+                "ValidateSlug": null,
+              },
+              "errors": Array [
+                [GraphQLError: userId is not set via query string.],
+              ],
+            }
+          `);
+  });
+
+  it('returns error for invalid slug', async () => {
+    await expect(
+      gql`
+        {
+          ValidateSlug(slug: "taken") {
+            success
+            error
+          }
+        }
+      `(
+        {},
+        {
+          userId: 'other-user',
+          appId: 'some-app',
+        }
+      )
+    ).resolves.toMatchInlineSnapshot(`
+            Object {
+              "data": Object {
+                "ValidateSlug": Object {
+                  "error": "TAKEN",
+                  "success": false,
+                },
+              },
+            }
+          `);
+  });
+
+  it('returns success for valid slug', async () => {
+    await expect(
+      gql`
+        {
+          ValidateSlug(slug: "valid") {
+            success
+            error
+          }
+        }
+      `(
+        {},
+        {
+          userId: 'other-user',
+          appId: 'some-app',
+        }
+      )
+    ).resolves.toMatchInlineSnapshot(`
+            Object {
+              "data": Object {
+                "ValidateSlug": Object {
+                  "error": null,
+                  "success": true,
+                },
+              },
+            }
+          `);
+  });
+});

--- a/src/graphql/queries/__tests__/ValidateSlug.js
+++ b/src/graphql/queries/__tests__/ValidateSlug.js
@@ -45,6 +45,9 @@ describe('assertSlugIsValid', () => {
     await expect(assertSlugIsValid(':3', 'other-user')).rejects.toEqual(
       errors.HAS_URI_COMPONENT
     ); // :
+    await expect(assertSlugIsValid('#_#', 'other-user')).rejects.toEqual(
+      errors.HAS_URI_COMPONENT
+    ); // #
     await expect(assertSlugIsValid('1/2', 'other-user')).rejects.toEqual(
       errors.HAS_URI_COMPONENT
     ); // /

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -10,6 +10,7 @@ import ListReplies from './queries/ListReplies';
 import ListCategories from './queries/ListCategories';
 import ListArticleReplyFeedbacks from './queries/ListArticleReplyFeedbacks';
 import ListReplyRequests from './queries/ListReplyRequests';
+import ValidateSlug from './queries/ValidateSlug';
 
 // Set individual objects
 import CreateArticle from './mutations/CreateArticle';
@@ -38,6 +39,7 @@ export default new GraphQLSchema({
       ListCategories,
       ListArticleReplyFeedbacks,
       ListReplyRequests,
+      ValidateSlug,
     },
   }),
   mutation: new GraphQLObjectType({

--- a/src/util/user.js
+++ b/src/util/user.js
@@ -19,6 +19,11 @@ import crypto from 'crypto';
 
 export const AUTH_ERROR_MSG = 'userId is not set via query string.';
 
+/**
+ * @param {object} param
+ * @param {string} param.userId
+ * @param {string} param.appId
+ */
 export function assertUser({ userId, appId }) {
   if (!userId) {
     throw new Error(AUTH_ERROR_MSG);


### PR DESCRIPTION
This PR fixes #242 .

The definition of "invalid slug": matches any of the following
- empty, or contains just space
- has trailing or leading space
- contains URL components like `:` or `/`
- is already taken by another user

This PR
- adds a query API `ValidateSlug` for UI to check if a slug is valid
- blocks invalid slug in `UpdateUser`
