### PR TITLE
Use FB Graph API v10

### DIFF
--- a/src/auth.js
+++ b/src/auth.js
@@ -121,6 +121,7 @@ if (process.env.FACEBOOK_APP_ID) {
         clientSecret: process.env.FACEBOOK_SECRET,
         callbackURL: process.env.FACEBOOK_CALLBACK_URL,
         profileFields: ['id', 'displayName', 'photos', 'email'],
+        graphAPIVersion: 'v10.0',
       },
       (token, tokenSecret, profile, done) =>
         verifyProfile(profile, 'facebookId')


### PR DESCRIPTION
FB Graph API v3.2 is going to be deprecated on May 04 2021. This PR upgrades Graph API we use to login users to the latest v10.0.

Doc: https://github.com/jaredhanson/passport-facebook/pull/234#issuecomment-456553856

## Screenshot
After clicking "Facebook" login button, it's being redirected to `v10.0` endpoint before being shown a FB login screen.
<img width="1440" alt="version" src="https://user-images.githubusercontent.com/108608/113594193-ee610400-9669-11eb-93f1-2c8a7856bdf3.png">


## Compatibility
Facebook reports that there will be no breaking change

![image](https://user-images.githubusercontent.com/108608/113590908-d7201780-9665-11eb-85e0-77eb69ecd01a.png)
