### PR TITLE
Fix web users cannot submit reply requests

### DIFF
--- a/src/util/__fixtures__/user.js
+++ b/src/util/__fixtures__/user.js
@@ -4,4 +4,7 @@ export default {
     appUserId: 'testUser1',
     appId: 'TEST_BACKEND',
   },
+  '/users/doc/web-user': {
+    name: 'Web user',
+  },
 };

--- a/src/util/__tests__/__snapshots__/user.js.snap
+++ b/src/util/__tests__/__snapshots__/user.js.snap
@@ -31,6 +31,19 @@ Object {
 }
 `;
 
+exports[`user utils CreateOrUpdateUser fills appId for website users 1`] = `
+Object {
+  "_cursor": undefined,
+  "_score": undefined,
+  "appId": "WEBSITE",
+  "highlight": undefined,
+  "id": "web-user",
+  "inner_hits": undefined,
+  "lastActiveAt": "2020-10-10T01:00:00.000Z",
+  "name": "Web user",
+}
+`;
+
 exports[`user utils CreateOrUpdateUser logs error if collision occurs 1`] = `
 Object {
   "_cursor": undefined,

--- a/src/util/__tests__/user.js
+++ b/src/util/__tests__/user.js
@@ -291,5 +291,20 @@ describe('user utils', () => {
       expect(rollbar.error.mock.calls).toMatchSnapshot();
       rollbar.error.mockClear();
     });
+
+    it('fills appId for website users', async () => {
+      MockDate.set(1602291600000);
+
+      const userId = 'web-user';
+      const appId = 'WEBSITE';
+
+      const { user, isCreated } = await createOrUpdateUser({
+        userId,
+        appId,
+      });
+
+      expect(isCreated).toBe(false);
+      expect(user).toMatchSnapshot();
+    });
   });
 });

--- a/src/util/user.js
+++ b/src/util/user.js
@@ -236,7 +236,7 @@ export async function createOrUpdateUser({ userId, appId }) {
   }
 
   return {
-    user,
+    user: { appId /* fill in appId for website users */, ...user },
     isCreated,
   };
 }


### PR DESCRIPTION
Issue: website users cannot submit reply requests in [release tests](https://g0v.hackmd.io/rf0A7MRfTOC613QZmFehQA#%E2%9B%94%EF%B8%8F-Release-Blockers).

Root cause: in #263 we use `user.id` and `user.appId` in GraphQL context instead of from GraphQL context, for several APIs including `CreateOrUpdateReplyRequest`.

However, website users actually do not have `user.appId`, as it is a new field.

This PR fixes the bug by making the utility function `createOrUpdateUser` always fill in `appId` for web users.

Note: this PR does not change the registration process via passport.js. Therefore, new website users still do not have `appId` in its `users` document as before.