### PR TITLE
Script that sets blockedReason and blocks reply rquests

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,15 @@ $ node build/scripts/removeArticleReply.js --userId=<userId> --articleId=<articl
 
 -  For more options, run the above script with `--help` or see the file level comments.
 
+### Block a user
+- Please announce that the user will be blocked openly with a URL first.
+- To block a user, execute the following:
+```
+$ node build/scripts/blockUser.js --userId=<userId> --blockedReason=<Announcement URL>
+```
+
+-  For more options, run the above script with `--help` or see the file level comments.
+
 
 ## One-off migration scripts
 

--- a/src/scripts/__fixtures__/blockUser.js
+++ b/src/scripts/__fixtures__/blockUser.js
@@ -1,11 +1,9 @@
 export default {
   '/users/doc/user-to-block': {
-    id: 'user-to-block',
     name: 'Naughty spammer',
   },
 
   '/users/doc/already-blocked': {
-    id: 'already-blocked',
     name: 'Blocked spammer',
     blockedReason: 'Some announcement',
   },

--- a/src/scripts/__fixtures__/blockUser.js
+++ b/src/scripts/__fixtures__/blockUser.js
@@ -7,4 +7,35 @@ export default {
     name: 'Blocked spammer',
     blockedReason: 'Some announcement',
   },
+
+  '/replyrequests/doc/already-blocked': {
+    articleId: 'some-article',
+    userId: 'user-to-block',
+    status: 'BLOCKED',
+    createdAt: '2021-11-11T00:00:00.000Z',
+  },
+
+  '/articles/doc/some-article': {
+    replyRequestCount: 1,
+    lastRequestedAt: '2021-01-01T00:00.000Z',
+  },
+
+  '/replyrequests/doc/replyrequest-to-block': {
+    articleId: 'modified-article',
+    userId: 'user-to-block',
+    status: 'NORMAL',
+    createdAt: '2021-11-11T11:00:00.000Z',
+  },
+
+  '/replyrequests/doc/valid-reply-request': {
+    articleId: 'modified-article',
+    userId: 'valid-user',
+    status: 'NORMAL',
+    createdAt: '2021-10-10T00:00:00.000Z',
+  },
+
+  '/articles/doc/modified-article': {
+    replyRequestCount: 2,
+    lastRequestedAt: '2021-01-01T00:00:01.000Z',
+  },
 };

--- a/src/scripts/__fixtures__/blockUser.js
+++ b/src/scripts/__fixtures__/blockUser.js
@@ -1,0 +1,12 @@
+export default {
+  '/users/doc/user-to-block': {
+    id: 'user-to-block',
+    name: 'Naughty spammer',
+  },
+
+  '/users/doc/already-blocked': {
+    id: 'already-blocked',
+    name: 'Blocked spammer',
+    blockedReason: 'Some announcement',
+  },
+};

--- a/src/scripts/__tests__/blockUser.js
+++ b/src/scripts/__tests__/blockUser.js
@@ -1,5 +1,5 @@
 import { loadFixtures, unloadFixtures } from 'util/fixtures';
-// import client from 'util/client';
+import client from 'util/client';
 import blockUser from '../blockUser';
 import fixtures from '../__fixtures__/blockUser';
 
@@ -14,8 +14,27 @@ it('fails if userId is not valid', async () => {
   );
 });
 
-it('Cannot block with identical reason', async () => {
-  expect(
-    blockUser({ userId: 'already-blocked', blockedReason: 'Some annoucement' })
-  ).rejects.toMatchInlineSnapshot();
+it('correctly sets the block reason and updates status of their works', async () => {
+  await blockUser({
+    userId: 'user-to-block',
+    blockedReason: 'announcement url',
+  });
+
+  const {
+    body: { _source: blockedUser },
+  } = await client.get({
+    index: 'users',
+    type: 'doc',
+    id: 'user-to-block',
+  });
+
+  // Assert that blockedReason is written on the user
+  expect(blockedUser).toMatchInlineSnapshot(`
+    Object {
+      "blockedReason": "announcement url",
+      "name": "Naughty spammer",
+    }
+  `);
 });
+
+// it('still updates statuses of blocked user even if they are blocked previously')

--- a/src/scripts/__tests__/blockUser.js
+++ b/src/scripts/__tests__/blockUser.js
@@ -35,6 +35,47 @@ it('correctly sets the block reason and updates status of their works', async ()
       "name": "Naughty spammer",
     }
   `);
+
+  //
+  // Check reply requests
+  //
+
+  // Assert reply requests that is already blocked are not selected to update
+  //
+  const {
+    body: { _source: someArticleWithAlreadyBlockedReplyRequest },
+  } = await client.get({
+    index: 'articles',
+    type: 'doc',
+    id: 'some-article',
+  });
+  expect(someArticleWithAlreadyBlockedReplyRequest).toMatchObject(
+    fixtures['/articles/doc/some-article']
+  );
+
+  // Assert normal reply requests being blocked and article being updated
+  //
+  const {
+    body: { _source: replyRequestToBlock },
+  } = await client.get({
+    index: 'replyrequests',
+    type: 'doc',
+    id: 'replyrequest-to-block',
+  });
+  expect(replyRequestToBlock.status).toEqual('BLOCKED');
+  const {
+    body: { _source: modifiedArticle },
+  } = await client.get({
+    index: 'articles',
+    type: 'doc',
+    id: 'modified-article',
+  });
+  expect(modifiedArticle).toMatchObject({
+    // Only replyrequests/doc/valid-reply-request
+    replyRequestCount: 1,
+    lastRequestedAt:
+      fixtures['/replyrequests/doc/valid-reply-request'].createdAt,
+  });
 });
 
 // it('still updates statuses of blocked user even if they are blocked previously')

--- a/src/scripts/__tests__/blockUser.js
+++ b/src/scripts/__tests__/blockUser.js
@@ -1,0 +1,21 @@
+import { loadFixtures, unloadFixtures } from 'util/fixtures';
+// import client from 'util/client';
+import blockUser from '../blockUser';
+import fixtures from '../__fixtures__/blockUser';
+
+beforeEach(() => loadFixtures(fixtures));
+afterEach(() => unloadFixtures(fixtures));
+
+it('fails if userId is not valid', async () => {
+  expect(
+    blockUser({ userId: 'not-exist', blockedReason: 'announcement url' })
+  ).rejects.toMatchInlineSnapshot(
+    `[Error: User with ID=not-exist does not exist]`
+  );
+});
+
+it('Cannot block with identical reason', async () => {
+  expect(
+    blockUser({ userId: 'already-blocked', blockedReason: 'Some annoucement' })
+  ).rejects.toMatchInlineSnapshot();
+});

--- a/src/scripts/blockUser.js
+++ b/src/scripts/blockUser.js
@@ -34,6 +34,7 @@ async function writeBlockedReasonToUser(userId, blockedReason) {
       );
     }
   } catch (e) {
+    /* istanbul ignore else */
     if (e.message === 'document_missing_exception') {
       throw new Error(`User with ID=${userId} does not exist`);
     }

--- a/src/scripts/blockUser.js
+++ b/src/scripts/blockUser.js
@@ -21,8 +21,12 @@ async function main({ userId, blockedReason } = {}) {
         doc: { blockedReason },
       },
     });
+
+    /* istanbul ignore if */
     if (setBlockedReasonResult === 'noop') {
-      throw new Error(`Cannot set user ${userId}'s blocked reason'`);
+      console.log(
+        `Info: user ID ${userId} already has set the same blocked reason.`
+      );
     }
   } catch (e) {
     if (e.message === 'document_missing_exception') {

--- a/src/scripts/blockUser.js
+++ b/src/scripts/blockUser.js
@@ -10,20 +10,26 @@ import client from 'util/client';
  * @param {object} args
  */
 async function main({ userId, blockedReason } = {}) {
-  const {
-    body: { result: setBlockedReasonResult },
-  } = await client.update({
-    index: 'users',
-    type: 'doc',
-    id: userId,
-    body: {
-      doc: { blockedReason },
-    },
-  });
+  try {
+    const {
+      body: { result: setBlockedReasonResult },
+    } = await client.update({
+      index: 'users',
+      type: 'doc',
+      id: userId,
+      body: {
+        doc: { blockedReason },
+      },
+    });
+    if (setBlockedReasonResult === 'noop') {
+      throw new Error(`Cannot set user ${userId}'s blocked reason'`);
+    }
+  } catch (e) {
+    if (e.message === 'document_missing_exception') {
+      throw new Error(`User with ID=${userId} does not exist`);
+    }
 
-  /* istanbul ignore if */
-  if (setBlockedReasonResult === 'noop') {
-    throw new Error(`Cannot set user ${userId}'s blocked reason'`);
+    throw e;
   }
 }
 

--- a/src/scripts/blockUser.js
+++ b/src/scripts/blockUser.js
@@ -1,15 +1,20 @@
+/**
+ * Given userId & block reason, blocks the user and marks all their existing ArticleReply,
+ * ArticleReplyFeedback, ReplyRequest, ArticleCategory, ArticleCategoryFeedback as BLOCKED.
+ */
+
 import 'dotenv/config';
 import yargs from 'yargs';
 // import { SingleBar } from 'cli-progress';
 import client from 'util/client';
 
 /**
- * Given userId & block reason, blocks the user and marks all their existing ArticleReply,
- * ArticleReplyFeedback, ReplyRequest, ArticleCategory, ArticleCategoryFeedback as BLOCKED.
+ * Update user to write blockedReason. Throws if user does not exist.
  *
- * @param {object} args
+ * @param {string} userId
+ * @param {string} blockedReason
  */
-async function main({ userId, blockedReason } = {}) {
+async function writeBlockedReasonToUser(userId, blockedReason) {
   try {
     const {
       body: { result: setBlockedReasonResult },
@@ -35,6 +40,21 @@ async function main({ userId, blockedReason } = {}) {
 
     throw e;
   }
+}
+
+/**
+ * Convert all article replies with NORMAL status by the user to BLOCKED status.
+ *
+ * @param {userId} userId
+ */
+async function processArticleReplies(/* userId */) {}
+
+/**
+ * @param {object} args
+ */
+async function main({ userId, blockedReason } = {}) {
+  await writeBlockedReasonToUser(userId, blockedReason);
+  await processArticleReplies(userId);
 }
 
 export default main;

--- a/src/scripts/blockUser.js
+++ b/src/scripts/blockUser.js
@@ -1,0 +1,51 @@
+import 'dotenv/config';
+import yargs from 'yargs';
+// import { SingleBar } from 'cli-progress';
+import client from 'util/client';
+
+/**
+ * Given userId & block reason, blocks the user and marks all their existing ArticleReply,
+ * ArticleReplyFeedback, ReplyRequest, ArticleCategory, ArticleCategoryFeedback as BLOCKED.
+ *
+ * @param {object} args
+ */
+async function main({ userId, blockedReason } = {}) {
+  const {
+    body: { result: setBlockedReasonResult },
+  } = await client.update({
+    index: 'users',
+    type: 'doc',
+    id: userId,
+    body: {
+      doc: { blockedReason },
+    },
+  });
+
+  /* istanbul ignore if */
+  if (setBlockedReasonResult === 'noop') {
+    throw new Error(`Cannot set user ${userId}'s blocked reason'`);
+  }
+}
+
+export default main;
+
+if (require.main === module) {
+  const argv = yargs
+    .options({
+      userId: {
+        alias: 'u',
+        description: 'The user ID to block',
+        type: 'string',
+        demandOption: true,
+      },
+      blockedReason: {
+        alias: 'r',
+        description: 'The URL to the annoucement that blocks this user',
+        type: 'string',
+        demandOption: true,
+      },
+    })
+    .help('help').argv;
+
+  main(argv).catch(console.error);
+}


### PR DESCRIPTION
Implements part of the blocking mechanism (ReplyRequest only) designed as the [2nd milestone in the User Blocking feature](https://g0v.hackmd.io/@mrorz/cofacts-meeting-notes/%2Frf0A7MRfTOC613QZmFehQA).

- A script, `blockUser`, is added to set blocked reason (expected to be an URL to an announcement) and changes the user's normal `replyRequest` status
- Update article's reply request count & last replied at using the remaining normal replyRequests
- The scripts can be executed multiple times in case of error
     - It is tested using production snapshot data; did not encounter any error.