### PR TITLE
2nd script of category review

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -72,6 +72,9 @@ GA_PAGE_SIZE=10000
 GA_WEB_VIEW_ID=GA_WEB_VIEW_ID
 GA_LINE_VIEW_ID=GA_LINE_VIEW_ID
 
+# Google API key for reading category review sheet
+GOOGLE_SHEETS_API_KEY=
+
 # URL to URL resolver microservice (http://github.com/cofacts/url-resolver)
 URL_RESOLVER_URL=localhost:4000
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ First, fill in GOOGLE_SHEETS_API_KEY in `.env`. The API key can be created from 
 
 Then, run:
 ```
-$ node build/scripts/genBERTInputArticles.js -s <Google spreadsheet ID> -o <Output directory>
+$ node -- build/scripts/genBERTInputArticles.js -s <Google spreadsheet ID> -o <Output directory>
 ```
 
 The ground truth files in JSON will be written to output directory

--- a/README.md
+++ b/README.md
@@ -195,8 +195,10 @@ First, fill in GOOGLE_SHEETS_API_KEY in `.env`. The API key can be created from 
 
 Then, run:
 ```
-$ node build/scripts/genBERTInputArticles.js -s <Google spreadsheet ID>
+$ node build/scripts/genBERTInputArticles.js -s <Google spreadsheet ID> -o <Output directory>
 ```
+
+The ground truth files in JSON will be written to output directory
 
 ## One-off migration scripts
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,14 @@ $ node build/scripts/genCategoryReview.js -f <ISO Timestamp>
 
 -  For more options, run the above script with `--help` or see the file level comments.
 
+### Write article-categories result back to DB and generate ground truth files
+First, fill in GOOGLE_SHEETS_API_KEY in `.env`. The API key can be created from [credentials](https://console.cloud.google.com/apis/credentials) page of Google Cloud Platform. We will only access Google Sheets API using this key.
+
+Then, run:
+```
+$ node build/scripts/genBERTInputArticles.js -s <Google spreadsheet ID>
+```
+
 ## One-off migration scripts
 
 ### Fill in `urls` index and `hyperlinks` field for all articles & replies

--- a/src/scripts/__fixtures__/genBERTInputArticles.js
+++ b/src/scripts/__fixtures__/genBERTInputArticles.js
@@ -1,3 +1,11 @@
+import { convertAppUserIdToUserId } from 'util/user';
+import { getArticleCategoryFeedbackId } from 'graphql/mutations/CreateOrUpdateArticleCategoryFeedback';
+
+export const reviewerUserId = convertAppUserIdToUserId({
+  appUserId: 'category-reviewer',
+  appId: 'RUMORS_AI',
+});
+
 export default {
   '/articles/doc/a1': {
     text: 'The article content',
@@ -8,7 +16,8 @@ export default {
         userId: 'one-user',
         appId: 'WEBSITE',
         positiveFeedbackCount: 0,
-        negativeFeedbackCount: 0,
+        // Previously reviewer gives negative feedback
+        negativeFeedbackCount: 1,
         createdAt: '2021-01-01T00:00:00.000Z',
         status: 'NORMAL',
       },
@@ -68,6 +77,21 @@ export default {
         status: 'DELETED',
       },
     ],
+  },
+  [`/articlecategoryfeedbacks/doc/${getArticleCategoryFeedbackId({
+    articleId: 'a1',
+    categoryId: 'c1',
+    userId: reviewerUserId,
+    appId: 'RUMORS_AI',
+  })}`]: {
+    articleId: 'a1',
+    categoryId: 'c1',
+    appId: 'RUMORS_AI',
+    userId: reviewerUserId,
+    score: -1,
+    comment: 'Previous deny reason',
+    status: 'NORMAL',
+    createdAt: '2019-01-01T00:00:00.000Z',
   },
   '/categories/doc/c1': {
     title: 'Category 1',

--- a/src/scripts/__fixtures__/genBERTInputArticles.js
+++ b/src/scripts/__fixtures__/genBERTInputArticles.js
@@ -1,0 +1,47 @@
+export default {
+  '/articles/doc/a1': {
+    text: 'The article content',
+    normalArticleCategoryCount: 3,
+    articleCategories: [
+      {
+        categoryId: 'c1',
+        userId: 'one-user',
+        appId: 'WEBSITE',
+        positiveFeedbackCount: 0,
+        negativeFeedbackCount: 0,
+        createdAt: '2021-01-01T00:00:00.000Z',
+        status: 'NORMAL',
+      },
+      {
+        categoryId: 'c2',
+        userId: 'an-user',
+        appId: 'WEBSITE',
+        positiveFeedbackCount: 0,
+        negativeFeedbackCount: 0,
+        createdAt: '2021-01-01T00:00:00.000Z',
+        status: 'NORMAL',
+      },
+      {
+        categoryId: 'c3',
+        userId: 'some-user',
+        appId: 'WEBSITE',
+        positiveFeedbackCount: 0,
+        negativeFeedbackCount: 0,
+        createdAt: '2021-01-01T00:00:00.000Z',
+        status: 'NORMAL',
+      },
+    ],
+  },
+  '/categories/doc/c1': {
+    title: 'Category 1',
+    description: 'Description for category 1',
+  },
+  '/categories/doc/c2': {
+    title: 'Category 2',
+    description: 'Description for category 2',
+  },
+  '/categories/doc/c3': {
+    title: 'Category 3',
+    description: 'Description for category 3',
+  },
+};

--- a/src/scripts/__fixtures__/genBERTInputArticles.js
+++ b/src/scripts/__fixtures__/genBERTInputArticles.js
@@ -32,6 +32,43 @@ export default {
       },
     ],
   },
+  '/articles/doc/a2': {
+    text: 'The exported article',
+    normalArticleCategoryCount: 2,
+    createdAt: '2020-11-01T00:00:00.000Z',
+    articleCategories: [
+      // Not included by getDocToExport() due to score sum = 0
+      {
+        categoryId: 'c1',
+        userId: 'one-user',
+        appId: 'WEBSITE',
+        positiveFeedbackCount: 1,
+        negativeFeedbackCount: 1,
+        createdAt: '2021-01-01T00:00:00.000Z',
+        status: 'NORMAL',
+      },
+      // Included by getDocToExport() due to positive > negative
+      {
+        categoryId: 'c2',
+        userId: 'an-user',
+        appId: 'WEBSITE',
+        positiveFeedbackCount: 2,
+        negativeFeedbackCount: 1,
+        createdAt: '2021-01-01T00:00:00.000Z',
+        status: 'NORMAL',
+      },
+      // Not included by getDocToExport() because it is deleted
+      {
+        categoryId: 'c3',
+        userId: 'some-user',
+        appId: 'WEBSITE',
+        positiveFeedbackCount: 1,
+        negativeFeedbackCount: 0,
+        createdAt: '2021-01-01T00:00:00.000Z',
+        status: 'DELETED',
+      },
+    ],
+  },
   '/categories/doc/c1': {
     title: 'Category 1',
     description: 'Description for category 1',

--- a/src/scripts/__fixtures__/genBERTInputArticles.js
+++ b/src/scripts/__fixtures__/genBERTInputArticles.js
@@ -76,6 +76,16 @@ export default {
         createdAt: '2021-01-01T00:00:00.000Z',
         status: 'DELETED',
       },
+      // Not included because it is too new
+      {
+        categoryId: 'c3',
+        userId: 'some-user',
+        appId: 'WEBSITE',
+        positiveFeedbackCount: 1,
+        negativeFeedbackCount: 0,
+        createdAt: '2021-10-01T00:00:00.000Z',
+        status: 'NORMAL',
+      },
     ],
   },
   [`/articlecategoryfeedbacks/doc/${getArticleCategoryFeedbackId({
@@ -104,5 +114,9 @@ export default {
   '/categories/doc/c3': {
     title: 'Category 3',
     description: 'Description for category 3',
+  },
+  '/categories/doc/c4': {
+    title: 'Category 4',
+    description: 'Description for category 4',
   },
 };

--- a/src/scripts/__tests__/genBERTInputArticles.js
+++ b/src/scripts/__tests__/genBERTInputArticles.js
@@ -178,8 +178,23 @@ describe('getDocToExport', () => {
   afterEach(() => unloadFixtures(fixtures));
 
   it('iterates through articles with matching article-categories', async () => {
+    const articleCategories = [
+      {
+        'Category ID': 'c1',
+        'Article ID': 'a1',
+        'Adopt?': true,
+        'Connected At': '2021-01-16T12:26:18.395Z',
+      },
+      {
+        'Category ID': 'c2',
+        'Article ID': 'a1',
+        'Adopt?': false,
+        'Connected At': '2021-01-21T12:56:00.381Z',
+      },
+    ];
+
     const articles = [];
-    for await (const article of getDocToExport()) {
+    for await (const article of getDocToExport(articleCategories)) {
       articles.push(article);
     }
 

--- a/src/scripts/__tests__/genBERTInputArticles.js
+++ b/src/scripts/__tests__/genBERTInputArticles.js
@@ -1,20 +1,14 @@
 import MockDate from 'mockdate';
 import client from 'util/client';
 import { loadFixtures, unloadFixtures } from 'util/fixtures';
-import { convertAppUserIdToUserId } from 'util/user';
 import {
   getDocToExport,
   range2Objects,
   writeFeedbacks,
 } from '../genBERTInputArticles';
-import fixtures from '../__fixtures__/genBERTInputArticles';
+import fixtures, { reviewerUserId } from '../__fixtures__/genBERTInputArticles';
 
 const FIXED_DATE = 612921600000;
-
-const reviewerUserId = convertAppUserIdToUserId({
-  appUserId: 'category-reviewer',
-  appId: 'RUMORS_AI',
-});
 
 describe('range2Objects', () => {
   it('converts range data to array of objects', () => {
@@ -70,7 +64,7 @@ describe('writeFeedbacks', () => {
       id: 'a1',
     });
 
-    // Check if c1 & c3 has 1 positive feedback each
+    // Check if c1 & c3 has 1 feedback each
     //
     expect(articleDoc.articleCategories).toMatchInlineSnapshot(`
       Array [
@@ -128,13 +122,16 @@ describe('writeFeedbacks', () => {
     const { _source: positiveFeedback } = articleCategoryFeedbacks.find(
       ({ _source }) => _source.score === 1
     );
+
+    // Assert the feedback has turn positive
     expect(positiveFeedback.userId).toBe(reviewerUserId);
     expect(positiveFeedback).toMatchInlineSnapshot(`
       Object {
         "appId": "RUMORS_AI",
         "articleId": "a1",
         "categoryId": "c1",
-        "createdAt": "1989-06-04T00:00:00.000Z",
+        "comment": "",
+        "createdAt": "2019-01-01T00:00:00.000Z",
         "score": 1,
         "status": "NORMAL",
         "updatedAt": "1989-06-04T00:00:00.000Z",

--- a/src/scripts/__tests__/genBERTInputArticles.js
+++ b/src/scripts/__tests__/genBERTInputArticles.js
@@ -1,0 +1,173 @@
+import MockDate from 'mockdate';
+import client from 'util/client';
+import { loadFixtures, unloadFixtures } from 'util/fixtures';
+import { convertAppUserIdToUserId } from 'util/user';
+import { range2Objects, writeFeedbacks } from '../genBERTInputArticles';
+import fixtures from '../__fixtures__/genBERTInputArticles';
+
+const FIXED_DATE = 612921600000;
+
+const reviewerUserId = convertAppUserIdToUserId({
+  appUserId: 'category-reviewer',
+  appId: 'RUMORS_AI',
+});
+
+describe('range2Objects', () => {
+  it('converts range data to array of objects', () => {
+    const array = range2Objects([['c1', 'c2'], ['v1', 'v2'], ['v3']]);
+
+    expect(array).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "c1": "v1",
+          "c2": "v2",
+        },
+        Object {
+          "c1": "v3",
+        },
+      ]
+    `);
+  });
+  it('handles empty range with header', () => {
+    const emptyArray = range2Objects([['c1', 'c2']]);
+    expect(emptyArray).toMatchInlineSnapshot(`Array []`);
+  });
+});
+
+describe('writeFeedbacks', () => {
+  beforeEach(() => loadFixtures(fixtures));
+  afterEach(() => unloadFixtures(fixtures));
+  it('writes feedbacks accordingly', async () => {
+    // Test input:
+    // c1 positive feedback
+    // c2 no feedback (left untouched)
+    // c3 negative feedback
+    //
+    const articleCategories = [
+      { 'Category ID': 'c1', 'Article ID': 'a1', 'Adopt?': true },
+      { 'Category ID': 'c2', 'Article ID': 'a1', 'Adopt?': false },
+      {
+        'Category ID': 'c3',
+        'Article ID': 'a1',
+        'Adopt?': false,
+        'Deny reason': 'The reason to deny',
+      },
+    ];
+
+    MockDate.set(FIXED_DATE);
+    await writeFeedbacks(articleCategories);
+    MockDate.reset();
+
+    const {
+      body: { _source: articleDoc },
+    } = await client.get({
+      index: 'articles',
+      type: 'doc',
+      id: 'a1',
+    });
+
+    // Check if c1 & c3 has 1 positive feedback each
+    //
+    expect(articleDoc.articleCategories).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "appId": "WEBSITE",
+          "categoryId": "c1",
+          "createdAt": "2021-01-01T00:00:00.000Z",
+          "negativeFeedbackCount": 0,
+          "positiveFeedbackCount": 1,
+          "status": "NORMAL",
+          "userId": "one-user",
+        },
+        Object {
+          "appId": "WEBSITE",
+          "categoryId": "c2",
+          "createdAt": "2021-01-01T00:00:00.000Z",
+          "negativeFeedbackCount": 0,
+          "positiveFeedbackCount": 0,
+          "status": "NORMAL",
+          "userId": "an-user",
+        },
+        Object {
+          "appId": "WEBSITE",
+          "categoryId": "c3",
+          "createdAt": "2021-01-01T00:00:00.000Z",
+          "negativeFeedbackCount": 1,
+          "positiveFeedbackCount": 0,
+          "status": "NORMAL",
+          "userId": "some-user",
+        },
+      ]
+    `);
+
+    // Check if article category feedbacks are generated correctly
+    //
+    const {
+      body: {
+        hits: { total, hits: articleCategoryFeedbacks },
+      },
+    } = await client.search({
+      index: 'articlecategoryfeedbacks',
+      body: {
+        query: {
+          term: {
+            appId: 'RUMORS_AI',
+          },
+        },
+      },
+    });
+
+    // Only 1 positive & 1 negative feedbacks inserted
+    //
+    expect(total).toBe(2);
+
+    const { _source: positiveFeedback } = articleCategoryFeedbacks.find(
+      ({ _source }) => _source.score === 1
+    );
+    expect(positiveFeedback.userId).toBe(reviewerUserId);
+    expect(positiveFeedback).toMatchInlineSnapshot(`
+      Object {
+        "appId": "RUMORS_AI",
+        "articleId": "a1",
+        "categoryId": "c1",
+        "createdAt": "1989-06-04T00:00:00.000Z",
+        "score": 1,
+        "status": "NORMAL",
+        "updatedAt": "1989-06-04T00:00:00.000Z",
+        "userId": "itezv_k4nL0AzYmLjGPIlwW2PDmpsp9LkDqRaQlIUjHlKNJfo",
+      }
+    `);
+
+    const { _source: negativeFeedback } = articleCategoryFeedbacks.find(
+      ({ _source }) => _source.score === -1
+    );
+    expect(negativeFeedback.userId).toBe(reviewerUserId);
+    expect(negativeFeedback).toMatchInlineSnapshot(`
+      Object {
+        "appId": "RUMORS_AI",
+        "articleId": "a1",
+        "categoryId": "c3",
+        "comment": "The reason to deny",
+        "createdAt": "1989-06-04T00:00:00.000Z",
+        "score": -1,
+        "status": "NORMAL",
+        "updatedAt": "1989-06-04T00:00:00.000Z",
+        "userId": "itezv_k4nL0AzYmLjGPIlwW2PDmpsp9LkDqRaQlIUjHlKNJfo",
+      }
+    `);
+
+    // Cleanup
+    //
+    await client.deleteByQuery({
+      index: 'articlecategoryfeedbacks',
+      body: {
+        query: {
+          term: {
+            appId: 'RUMORS_AI',
+          },
+        },
+      },
+    });
+    await client.delete({ index: 'users', type: 'doc', id: reviewerUserId });
+  });
+});

--- a/src/scripts/__tests__/genBERTInputArticles.js
+++ b/src/scripts/__tests__/genBERTInputArticles.js
@@ -42,12 +42,12 @@ describe('writeFeedbacks', () => {
     // c3 negative feedback
     //
     const articleCategories = [
-      { 'Category ID': 'c1', 'Article ID': 'a1', 'Adopt?': true },
-      { 'Category ID': 'c2', 'Article ID': 'a1', 'Adopt?': false },
+      { 'Category ID': 'c1', 'Article ID': 'a1', 'Adopt?': 'TRUE' },
+      { 'Category ID': 'c2', 'Article ID': 'a1', 'Adopt?': 'FALSE' },
       {
         'Category ID': 'c3',
         'Article ID': 'a1',
-        'Adopt?': false,
+        'Adopt?': 'FALSE',
         'Deny reason': 'The reason to deny',
       },
     ];
@@ -182,13 +182,13 @@ describe('getDocToExport', () => {
       {
         'Category ID': 'c1',
         'Article ID': 'a1',
-        'Adopt?': true,
+        'Adopt?': 'TRUE',
         'Connected At': '2021-01-21T12:56:00.381Z',
       },
       {
         'Category ID': 'c2',
         'Article ID': 'a1',
-        'Adopt?': false,
+        'Adopt?': 'FALSE',
         'Connected At': '2021-01-16T12:26:18.395Z',
       },
     ];

--- a/src/scripts/__tests__/genBERTInputArticles.js
+++ b/src/scripts/__tests__/genBERTInputArticles.js
@@ -2,7 +2,11 @@ import MockDate from 'mockdate';
 import client from 'util/client';
 import { loadFixtures, unloadFixtures } from 'util/fixtures';
 import { convertAppUserIdToUserId } from 'util/user';
-import { range2Objects, writeFeedbacks } from '../genBERTInputArticles';
+import {
+  getDocToExport,
+  range2Objects,
+  writeFeedbacks,
+} from '../genBERTInputArticles';
 import fixtures from '../__fixtures__/genBERTInputArticles';
 
 const FIXED_DATE = 612921600000;
@@ -169,5 +173,37 @@ describe('writeFeedbacks', () => {
       },
     });
     await client.delete({ index: 'users', type: 'doc', id: reviewerUserId });
+  });
+});
+
+describe('getDocToExport', () => {
+  beforeEach(() => loadFixtures(fixtures));
+  afterEach(() => unloadFixtures(fixtures));
+
+  it('iterates through articles with matching article-categories', async () => {
+    const articles = [];
+    for await (const article of getDocToExport()) {
+      articles.push(article);
+    }
+
+    // Expect only include article a2
+    //
+    expect(articles.length).toBe(1);
+
+    // Expect only include category c2 in article a2 as tags
+    //
+    expect(articles).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "createdAt": "2020-11-01T00:00:00.000Z",
+          "id": "a2",
+          "tags": Array [
+            "c2",
+          ],
+          "text": "The exported article",
+          "url": "https://cofacts.tw/article/a2",
+        },
+      ]
+    `);
   });
 });

--- a/src/scripts/__tests__/genBERTInputArticles.js
+++ b/src/scripts/__tests__/genBERTInputArticles.js
@@ -183,13 +183,13 @@ describe('getDocToExport', () => {
         'Category ID': 'c1',
         'Article ID': 'a1',
         'Adopt?': true,
-        'Connected At': '2021-01-16T12:26:18.395Z',
+        'Connected At': '2021-01-21T12:56:00.381Z',
       },
       {
         'Category ID': 'c2',
         'Article ID': 'a1',
         'Adopt?': false,
-        'Connected At': '2021-01-21T12:56:00.381Z',
+        'Connected At': '2021-01-16T12:26:18.395Z',
       },
     ];
 

--- a/src/scripts/genBERTInputArticles.js
+++ b/src/scripts/genBERTInputArticles.js
@@ -74,6 +74,8 @@ export async function writeFeedbacks(articleCategories) {
         categoryId,
         vote: 1,
         user: reviewer,
+        // Overwrite the previous comment
+        comment: '',
       });
       positiveCount += 1;
     } else if (denyReason) {

--- a/src/scripts/genBERTInputArticles.js
+++ b/src/scripts/genBERTInputArticles.js
@@ -1,0 +1,50 @@
+import 'dotenv/config';
+import fetch from 'node-fetch';
+
+/**
+ * @param {string[][]} range - Spreadsheet range data with 1st row being the column names
+ * @param {object[]}
+ */
+export function range2Objects(range) {
+  const [columnNames, ...dataRows] = range;
+  return dataRows.map(row =>
+    row.reduce((obj, cell, colIdx) => {
+      obj[columnNames[colIdx]] = cell;
+      return obj;
+    }, {})
+  );
+}
+
+/**
+ *
+ * @param {string} googleSheetId
+ * @param {{ mappings: object[], articleCategories: object[] }}
+ */
+async function readFromGoogleSheet(googleSheetId) {
+  const {
+    valueRanges: [
+      { values: articleCategoriesRange },
+      { values: mappingsRange },
+    ],
+  } = await (await fetch(
+    `https://sheets.googleapis.com/v4/spreadsheets/${googleSheetId}/values:batchGet?key=${
+      process.env.GOOGLE_SHEETS_API_KEY
+    }&ranges=Article categories!A1:L&ranges=Mappings!A1:C`
+  )).json();
+
+  return {
+    mappings: range2Objects(mappingsRange),
+    articleCategories: range2Objects(articleCategoriesRange),
+  };
+}
+
+async function main() {
+  console.log(
+    await readFromGoogleSheet('1Y9FrI01in2hz5eiveGknH0HE081sr7gVuk0a7hqqKuc')
+  );
+}
+
+/* istanbul ignore if */
+if (require.main === module) {
+  main().catch(console.error);
+}

--- a/src/scripts/genBERTInputArticles.js
+++ b/src/scripts/genBERTInputArticles.js
@@ -26,6 +26,7 @@ export function range2Objects(range) {
  * @param {string} googleSheetId
  * @param {{ mappings: object[], articleCategories: object[] }}
  */
+/* istanbul ignore next */
 async function readFromGoogleSheet(googleSheetId) {
   const {
     valueRanges: [
@@ -83,6 +84,7 @@ export async function writeFeedbacks(articleCategories) {
   bar.stop;
 }
 
+/* istanbul ignore next */
 async function main() {
   console.log(
     await readFromGoogleSheet('1Y9FrI01in2hz5eiveGknH0HE081sr7gVuk0a7hqqKuc')

--- a/src/scripts/genBERTInputArticles.js
+++ b/src/scripts/genBERTInputArticles.js
@@ -68,7 +68,7 @@ export async function writeFeedbacks(articleCategories) {
     'Adopt?': shouldAdopt,
     'Deny reason': denyReason,
   } of articleCategories) {
-    if (shouldAdopt) {
+    if (shouldAdopt === 'TRUE') {
       await createOrUpdateArticleCategoryFeedback({
         articleId,
         categoryId,

--- a/src/scripts/genBERTInputArticles.js
+++ b/src/scripts/genBERTInputArticles.js
@@ -56,6 +56,9 @@ export async function writeFeedbacks(articleCategories) {
   console.log('Writing feedbacks to database');
   const bar = new SingleBar({ stopOnComplete: true });
   bar.start(articleCategories.length, 0);
+  let positiveCount = 0;
+  let negativeCount = 0;
+
   for (const {
     'Category ID': categoryId,
     'Article ID': articleId,
@@ -69,6 +72,7 @@ export async function writeFeedbacks(articleCategories) {
         vote: 1,
         user: reviewer,
       });
+      positiveCount += 1;
     } else if (denyReason) {
       await createOrUpdateArticleCategoryFeedback({
         articleId,
@@ -77,6 +81,7 @@ export async function writeFeedbacks(articleCategories) {
         comment: denyReason,
         user: reviewer,
       });
+      negativeCount += 1;
     } else {
       // Do nothing if both "Adopt?" and "Deny reason" are empty
     }
@@ -84,6 +89,9 @@ export async function writeFeedbacks(articleCategories) {
     bar.increment();
   }
   bar.stop;
+  console.log(
+    `${positiveCount} positive feedbacks & ${negativeCount} negative feedbacks have been written.`
+  );
 }
 
 const ARTICLE_QUERY = {

--- a/src/scripts/genBERTInputArticles.js
+++ b/src/scripts/genBERTInputArticles.js
@@ -78,12 +78,12 @@ export async function writeFeedbacks(articleCategories) {
         comment: '',
       });
       positiveCount += 1;
-    } else if (denyReason) {
+    } else if (denyReason && denyReason.trim()) {
       await createOrUpdateArticleCategoryFeedback({
         articleId,
         categoryId,
         vote: -1,
-        comment: denyReason,
+        comment: denyReason.trim(),
         user: reviewer,
       });
       negativeCount += 1;

--- a/src/util/pseudonymDict.js
+++ b/src/util/pseudonymDict.js
@@ -1,3 +1,4 @@
+/* istanbul ignore file */
 /*
  * The lists of towns, names and adjectives come from PlatoForum:
  * https://github.com/PlatoForum/PlatoForum/tree/master/utils/pseudonym_gen


### PR DESCRIPTION
This PR implements [script 2](https://g0v.hackmd.io/EcrdwfZrQOSTGX7yK6nn4w?view#Script-2-genBERTInputArticles-script-in-rumors-api) in category review.

- `$ node build/scripts/genBERTInputArticles.js -s <Google spreadsheet ID> -o <Output directory>`
- Validation part is skipped to save time :P
- Generates JSON files with articles that has article categories satisfying all of:
    - created before `latestArticleCategoryCreatedAt` (sheet1 generation)
    - positive feedback > negative feedback
    - is not deleted nor blocked

Test run: around 10 minutes
> node_modules/.bin/babel-node -- src/scripts/genBERTInputArticles.js -s 1Y9FrI01in2hz5eiveGknH0HE081sr7gVuk0a7hqqKuc -o 20211128
> Writing feedbacks to database
> progress [========================================] 100% | ETA: 0s | 2989/2989
> 1418 positive feedbacks & 115 negative feedbacks have been written.
> Scanning through 15584 matching articles
> progress [========================================] 100% | ETA: 0s | 15584/15584