### PR TITLE
Block user script processes comments & feedbacks

### DIFF
--- a/src/scripts/__fixtures__/blockUser.js
+++ b/src/scripts/__fixtures__/blockUser.js
@@ -15,9 +15,20 @@ export default {
     createdAt: '2021-11-11T00:00:00.000Z',
   },
 
+  // Article with already-blocked contents
   '/articles/doc/some-article': {
     replyRequestCount: 1,
+    normalArticleReplyCount: 0,
     lastRequestedAt: '2021-01-01T00:00.000Z',
+    articleReplies: [
+      {
+        replyId: 'some-reply',
+        userId: 'already-blocked',
+        appId: 'APP_ID',
+        status: 'BLOCKED',
+        updatedAt: '2021-11-11T00:00:00.000Z',
+      },
+    ],
   },
 
   '/replyrequests/doc/replyrequest-to-block': {
@@ -34,8 +45,27 @@ export default {
     createdAt: '2021-10-10T00:00:00.000Z',
   },
 
+  // Article with normal contents to block
   '/articles/doc/modified-article': {
     replyRequestCount: 2,
+    normalArticleReplyCount: 2,
     lastRequestedAt: '2021-01-01T00:00:01.000Z',
+
+    articleReplies: [
+      {
+        replyId: 'valid-reply',
+        userId: 'valid-user',
+        appId: 'APP_ID',
+        status: 'NORMAL',
+        updatedAt: '2021-11-11T00:00:00.000Z',
+      },
+      {
+        replyId: 'some-reply',
+        userId: 'user-to-block',
+        appId: 'APP_ID',
+        status: 'NORMAL',
+        updatedAt: '2021-11-11T00:00:00.000Z',
+      },
+    ],
   },
 };

--- a/src/scripts/__fixtures__/blockUser.js
+++ b/src/scripts/__fixtures__/blockUser.js
@@ -58,6 +58,8 @@ export default {
         appId: 'APP_ID',
         status: 'NORMAL',
         updatedAt: '2021-11-11T00:00:00.000Z',
+        positiveFeedbackCount: 1,
+        negativeFeedbackCount: 1,
       },
       {
         replyId: 'some-reply',
@@ -65,7 +67,38 @@ export default {
         appId: 'APP_ID',
         status: 'NORMAL',
         updatedAt: '2021-11-11T00:00:00.000Z',
+        positiveFeedbackCount: 0,
+        negativeFeedbackCount: 1,
       },
     ],
+  },
+
+  '/articlereplyfeedbacks/doc/f-normal': {
+    userId: 'valid-user',
+    articleId: 'modified-article',
+    replyId: 'valid-reply',
+    score: 1,
+    status: 'NORMAL',
+  },
+  '/articlereplyfeedbacks/doc/f-normal-2': {
+    userId: 'valid-user',
+    articleId: 'modified-article',
+    replyId: 'some-reply',
+    score: -1,
+    status: 'NORMAL',
+  },
+  '/articlereplyfeedbacks/doc/f-spam': {
+    userId: 'user-to-block',
+    articleId: 'modified-article',
+    replyId: 'valid-reply',
+    score: -1,
+    status: 'NORMAL',
+  },
+  '/articlereplyfeedbacks/doc/f-already-blocked': {
+    userId: 'already-blocked',
+    articleId: 'some-article',
+    replyId: 'some-reply',
+    score: 1,
+    status: 'BLOCKED',
   },
 };

--- a/src/scripts/__tests__/blockUser.js
+++ b/src/scripts/__tests__/blockUser.js
@@ -107,10 +107,10 @@ it('correctly sets the block reason and updates status of their works', async ()
 
     // the negative feedback given by valid user is still there
     positiveFeedbackCount:
-      fixtures['/articles/doc/modified-article'].replyRequests[1]
+      fixtures['/articles/doc/modified-article'].articleReplies[1]
         .positiveFeedbackCount,
     negativeFeedbackCount:
-      fixtures['/articles/doc/modified-article'].replyRequests[1]
+      fixtures['/articles/doc/modified-article'].articleReplies[1]
         .negativeFeedbackCount,
   });
 
@@ -131,7 +131,7 @@ it('correctly sets the block reason and updates status of their works', async ()
     userId: 'valid-user',
     status: 'NORMAL',
     positiveFeedbackCount:
-      fixtures['/articles/doc/modified-article'].replyRequests[0]
+      fixtures['/articles/doc/modified-article'].articleReplies[0]
         .positiveFeedbackCount,
     negativeFeedbackCount: 0, // Originally 1
   });

--- a/src/scripts/__tests__/blockUser.js
+++ b/src/scripts/__tests__/blockUser.js
@@ -40,7 +40,7 @@ it('correctly sets the block reason and updates status of their works', async ()
   // Check reply requests
   //
 
-  // Assert reply requests that is already blocked are not selected to update
+  // Assert contents that is already blocked are not selected to update
   //
   const {
     body: { _source: someArticleWithAlreadyBlockedReplyRequest },
@@ -53,7 +53,7 @@ it('correctly sets the block reason and updates status of their works', async ()
     fixtures['/articles/doc/some-article']
   );
 
-  // Assert normal reply requests being blocked and article being updated
+  // Assert normal contents being blocked and article being updated
   //
   const {
     body: { _source: replyRequestToBlock },
@@ -63,6 +63,7 @@ it('correctly sets the block reason and updates status of their works', async ()
     id: 'replyrequest-to-block',
   });
   expect(replyRequestToBlock.status).toEqual('BLOCKED');
+
   const {
     body: { _source: modifiedArticle },
   } = await client.get({
@@ -71,10 +72,19 @@ it('correctly sets the block reason and updates status of their works', async ()
     id: 'modified-article',
   });
   expect(modifiedArticle).toMatchObject({
+    // Only the article reply by valid-user
+    normalArticleReplyCount: 1,
+
     // Only replyrequests/doc/valid-reply-request
     replyRequestCount: 1,
     lastRequestedAt:
       fixtures['/replyrequests/doc/valid-reply-request'].createdAt,
+  });
+
+  // Assert article reply being blocked
+  expect(modifiedArticle.articleReplies[1]).toMatchObject({
+    userId: 'user-to-block',
+    status: 'BLOCKED',
   });
 });
 

--- a/src/scripts/__tests__/blockUser.js
+++ b/src/scripts/__tests__/blockUser.js
@@ -14,6 +14,20 @@ it('fails if userId is not valid', async () => {
   );
 });
 
+/**
+ * Asserts the document in database is the same as in the fixture,
+ * i.e. the document is not modified
+ *
+ * @param {string} fixtureKey
+ * @param {{index: string; id: string;}} clientGetArgs - Arguments for client.get()
+ */
+async function expectSameAsFixture(fixtureKey, clientGetArgs) {
+  const {
+    body: { _source: docInDb },
+  } = await client.get({ ...clientGetArgs, type: 'doc' });
+  expect(docInDb).toMatchObject(fixtures[fixtureKey]);
+}
+
 it('correctly sets the block reason and updates status of their works', async () => {
   await blockUser({
     userId: 'user-to-block',
@@ -36,22 +50,27 @@ it('correctly sets the block reason and updates status of their works', async ()
     }
   `);
 
+  // Assert valid contents remain as-is
   //
-  // Check reply requests
-  //
+  await expectSameAsFixture('/replyrequests/doc/valid-reply-request', {
+    index: 'replyrequests',
+    id: 'valid-reply-request',
+  });
+  await expectSameAsFixture('/articlereplyfeedbacks/doc/f-normal', {
+    index: 'articlereplyfeedbacks',
+    id: 'f-normal',
+  });
 
   // Assert contents that is already blocked are not selected to update
   //
-  const {
-    body: { _source: someArticleWithAlreadyBlockedReplyRequest },
-  } = await client.get({
+  await expectSameAsFixture('/articles/doc/some-article', {
     index: 'articles',
-    type: 'doc',
     id: 'some-article',
   });
-  expect(someArticleWithAlreadyBlockedReplyRequest).toMatchObject(
-    fixtures['/articles/doc/some-article']
-  );
+  await expectSameAsFixture('/articlereplyfeedbacks/doc/f-already-blocked', {
+    index: 'articlereplyfeedbacks',
+    id: 'f-already-blocked',
+  });
 
   // Assert normal contents being blocked and article being updated
   //
@@ -85,6 +104,36 @@ it('correctly sets the block reason and updates status of their works', async ()
   expect(modifiedArticle.articleReplies[1]).toMatchObject({
     userId: 'user-to-block',
     status: 'BLOCKED',
+
+    // the negative feedback given by valid user is still there
+    positiveFeedbackCount:
+      fixtures['/articles/doc/modified-article'].replyRequests[1]
+        .positiveFeedbackCount,
+    negativeFeedbackCount:
+      fixtures['/articles/doc/modified-article'].replyRequests[1]
+        .negativeFeedbackCount,
+  });
+
+  // Assert article reply feedback is being blocked
+  //
+  const {
+    body: { _source: articleReplyFeedbackToBlock },
+  } = await client.get({
+    index: 'articlereplyfeedbacks',
+    type: 'doc',
+    id: 'f-spam',
+  });
+  expect(articleReplyFeedbackToBlock.status).toEqual('BLOCKED');
+
+  // Assert malicious negative feedback is removed from normal article reply
+  //
+  expect(modifiedArticle.articleReplies[0]).toMatchObject({
+    userId: 'valid-user',
+    status: 'NORMAL',
+    positiveFeedbackCount:
+      fixtures['/articles/doc/modified-article'].replyRequests[0]
+        .positiveFeedbackCount,
+    negativeFeedbackCount: 0, // Originally 1
   });
 });
 

--- a/src/scripts/blockUser.js
+++ b/src/scripts/blockUser.js
@@ -245,15 +245,18 @@ async function processArticleReplyFeedbacks(userId) {
     { articleId, replyId },
   ] of articleReplyIdsWithNormalFeedbacks.entries()) {
     const feedbacks = [];
-    for (const feedback of getAllDocs('articlereplyfeedbacks', {
-      bool: {
-        must: [
-          { term: { status: 'NORMAL' } },
-          { term: { articleId } },
-          { term: { replyId } },
-        ],
-      },
-    })) {
+    for await (const { _source: feedback } of getAllDocs(
+      'articlereplyfeedbacks',
+      {
+        bool: {
+          must: [
+            { term: { status: 'NORMAL' } },
+            { term: { articleId } },
+            { term: { replyId } },
+          ],
+        },
+      }
+    )) {
       feedbacks.push(feedback);
     }
 


### PR DESCRIPTION
This implements [user blocking mechanism M4](https://g0v.hackmd.io/hk1v8Ka5TCmIZinQ6zKU9Q?view#M4-Block-all-contents-from-blocked-users-).

`blockUser` script now turns existing article-replies & article-reply feedbacks into blocked state as well.
Both article's reply count & article reply's feedback counts are also updated after putting these existing contents to `BLOCKED` state.

Refactor: extract `updateArticleReplyByFeedbacks` logic so that `blockUser` can reuse.