### PR TITLE
List api enhancements

### DIFF
--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -61,10 +61,8 @@ export default {
         },
         fromUserOfArticleId: {
           type: GraphQLString,
-          description: `
-            Specify an articleId here to show only articles from the sender of that specified article.
-            When specified, it overrides the settings of appId and userId.
-          `,
+          description:
+            'Specify an articleId here to show only articles from the sender of that specified article.',
         },
         articleRepliesFrom: {
           description:
@@ -166,12 +164,10 @@ export default {
         throw e;
       }
 
-      // Overriding filter's userId and appId, as indicated in the description
-      //
-      // eslint-disable-next-line require-atomic-updates
-      filter.userId = specifiedArticle.userId;
-      // eslint-disable-next-line require-atomic-updates
-      filter.appId = specifiedArticle.appId;
+      filterQueries.push(
+        { term: { userId: specifiedArticle.userId } },
+        { term: { appId: specifiedArticle.appId } }
+      );
     }
 
     if (filter.moreLikeThis) {

--- a/src/graphql/queries/ListReplies.js
+++ b/src/graphql/queries/ListReplies.js
@@ -9,7 +9,6 @@ import {
   getSortArgs,
   pagingArgs,
   moreLikeThisInput,
-  getRangeFieldParamFromArithmeticExpression,
 } from 'graphql/util';
 import scrapUrls from 'util/scrapUrls';
 

--- a/src/graphql/queries/__tests__/ListReplyRequests.js
+++ b/src/graphql/queries/__tests__/ListReplyRequests.js
@@ -131,6 +131,23 @@ describe('ListReplyRequests', () => {
         }
       `()
     ).toMatchSnapshot('by createdAt');
+
+    expect(
+      await gql`
+        {
+          ListReplyRequests(
+            filter: { ids: ["replyrequests2", "replyrequests4"] }
+          ) {
+            edges {
+              node {
+                id
+              }
+            }
+            totalCount
+          }
+        }
+      `()
+    ).toMatchSnapshot('by ids');
   });
 
   it('filters by mixed query', async () => {

--- a/src/graphql/queries/__tests__/__snapshots__/ListReplyRequests.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListReplyRequests.js.snap
@@ -79,6 +79,28 @@ Object {
 }
 `;
 
+exports[`ListReplyRequests filters: by ids 1`] = `
+Object {
+  "data": Object {
+    "ListReplyRequests": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "replyrequests4",
+          },
+        },
+        Object {
+          "node": Object {
+            "id": "replyrequests2",
+          },
+        },
+      ],
+      "totalCount": 2,
+    },
+  },
+}
+`;
+
 exports[`ListReplyRequests filters: by userId 1`] = `
 Object {
   "data": Object {

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -486,7 +486,7 @@ export function attachCommonListFilter(filterQueries, filter, userId, appId) {
   }
 
   if (filter.ids) {
-    filterQueries.push({ ids: filter.ids });
+    filterQueries.push({ ids: { values: filter.ids } });
   }
 
   if (filter.selfOnly) {


### PR DESCRIPTION
- Introduce `ids` and `selfOnly` to `ListReplyRequests`, `ListArticles`, `ListReplies` and `ListReplyRequests`
- Implement utility `createCommonListFilter()` and `attachCommonListFilter()` as discussed in [3/30 meeting](https://g0v.hackmd.io/OdOwYeKjQsSyUVzuE-BGiw#%E9%80%81%E5%87%BA%E6%B5%81%E7%A8%8B%E6%94%B9%E7%89%88%E9%96%8B%E7%99%BC)
