### PR TITLE
Use buffer instead of cloned stream

### DIFF
--- a/src/graphql/mutations/CreateMediaArticle.js
+++ b/src/graphql/mutations/CreateMediaArticle.js
@@ -3,16 +3,13 @@ import { GraphQLString, GraphQLNonNull } from 'graphql';
 import { assertUser } from 'util/user';
 import client from 'util/client';
 import { uploadToGCS } from 'util/gcs';
-import { getMediaFileHash } from 'graphql/util';
+import { getMediaFileHash, MAX_FILE_SIZE } from 'graphql/util';
 
 import { ArticleReferenceInput } from 'graphql/models/ArticleReference';
 import MutationResult from 'graphql/models/MutationResult';
 import { createOrUpdateReplyRequest } from './CreateOrUpdateReplyRequest';
 import ArticleTypeEnum from 'graphql/models/ArticleTypeEnum';
 import fetch from 'node-fetch';
-
-/** Max downloadable file size */
-const MAX_FILE_SIZE = 5 * 1024 * 1024; // byte
 
 /**
  * @param {Buffer} fileBuffer

--- a/src/graphql/mutations/CreateMediaArticle.js
+++ b/src/graphql/mutations/CreateMediaArticle.js
@@ -11,13 +11,16 @@ import { createOrUpdateReplyRequest } from './CreateOrUpdateReplyRequest';
 import ArticleTypeEnum from 'graphql/models/ArticleTypeEnum';
 import fetch from 'node-fetch';
 
+/** Max downloadable file size */
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // byte
+
 /**
- * @param {NodeJS.ReadableStream} fileStream
+ * @param {Buffer} fileBuffer
  * @param {sring} name File name
  * @param {ArticleTypeEnum} type The article type
  * @returns {string} url
  */
-export async function uploadFile(fileStream, name, type) {
+export async function uploadFile(fileBuffer, name, type) {
   // final file name that combined with folder name.
   let fileName;
   let mimeType = '*/*';
@@ -31,7 +34,7 @@ export async function uploadFile(fileStream, name, type) {
 
     mimeType = 'image/jpeg';
   }
-  return await uploadToGCS(fileStream, fileName, mimeType);
+  return await uploadToGCS(fileBuffer, fileName, mimeType);
 }
 
 /**
@@ -57,11 +60,10 @@ async function createNewMediaArticle({
     throw new Error(`Type ${articleType} is not yet supported.`);
   }
 
-  const file = await fetch(mediaUrl);
-  const attachmentHash = await getMediaFileHash(
-    await file.clone().buffer(),
-    articleType
-  );
+  const fileBuffer = await (await fetch(mediaUrl, {
+    size: MAX_FILE_SIZE,
+  })).buffer();
+  const attachmentHash = await getMediaFileHash(fileBuffer, articleType);
   const text = '';
   const now = new Date().toISOString();
   const reference = {
@@ -88,7 +90,7 @@ async function createNewMediaArticle({
   }
 
   const attachmentUrl = await uploadFile(
-    file.body,
+    fileBuffer,
     attachmentHash,
     articleType
   );

--- a/src/graphql/mutations/__tests__/CreateMediaArticle.js
+++ b/src/graphql/mutations/__tests__/CreateMediaArticle.js
@@ -26,7 +26,7 @@ describe('creation', () => {
       Promise.resolve({
         status: 200,
         body: {},
-        clone: () => ({ buffer: jest.fn() }),
+        buffer: jest.fn(),
       })
     );
     imageHash.mockImplementation((file, bits, method, callback) =>
@@ -302,7 +302,7 @@ describe('error', () => {
       Promise.resolve({
         status: 200,
         body: {},
-        clone: () => ({ buffer: jest.fn() }),
+        buffer: jest.fn(),
       })
     );
     imageHash.mockImplementation((file, bits, method, callback) =>

--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -443,10 +443,9 @@ export default {
     }
 
     if (filter.mediaUrl) {
-      const file = await fetch(filter.mediaUrl);
       // FIXME: Use mime or binary header to get articleType instead of manual input
       const attachmentHash = await getMediaFileHash(
-        await file.clone().buffer(),
+        await (await fetch(filter.mediaUrl)).buffer(),
         'IMAGE'
       );
       filterQueries.push({

--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -19,6 +19,7 @@ import {
   createCommonListFilter,
   attachCommonListFilter,
   getMediaFileHash,
+  MAX_FILE_SIZE,
 } from 'graphql/util';
 import scrapUrls from 'util/scrapUrls';
 import ReplyTypeEnum from 'graphql/models/ReplyTypeEnum';
@@ -444,10 +445,10 @@ export default {
 
     if (filter.mediaUrl) {
       // FIXME: Use mime or binary header to get articleType instead of manual input
-      const attachmentHash = await getMediaFileHash(
-        await (await fetch(filter.mediaUrl)).buffer(),
-        'IMAGE'
-      );
+      const fileBuffer = await (await fetch(filter.mediaUrl, {
+        size: MAX_FILE_SIZE,
+      })).buffer();
+      const attachmentHash = await getMediaFileHash(fileBuffer, 'IMAGE');
       filterQueries.push({
         term: {
           attachmentHash,

--- a/src/graphql/queries/__tests__/ListArticles.js
+++ b/src/graphql/queries/__tests__/ListArticles.js
@@ -719,7 +719,7 @@ describe('ListArticles', () => {
       Promise.resolve({
         status: 200,
         body: {},
-        clone: () => ({ buffer: jest.fn() }),
+        buffer: jest.fn(),
       })
     );
     imageHash.mockImplementation((file, bits, method, callback) =>

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -430,6 +430,9 @@ export function filterByStatuses(entriesWithStatus, statuses) {
   return entriesWithStatus.filter(({ status }) => statuses.includes(status));
 }
 
+/** Max downloadable file size */
+export const MAX_FILE_SIZE = 5 * 1024 * 1024; // byte
+
 /**
  * @param {Buffer} fileBuffer
  * @param {ArticleTypeEnum} type The article type


### PR DESCRIPTION
Current implementation of `CreateMediaArticle` will halt on file larger than a certain size.

It is halt because `await file.clone().buffer()` never resolves.

The root cause is that when we call `await file.clone().buffer()`, it reads the cloned stream and put its data in an internal buffer so that the original stream can still consume data afterwards. The read operation halts when the internal buffer is full.

Related issue:
- https://github.com/node-fetch/node-fetch/issues/151
- https://github.com/node-fetch/node-fetch/issues/665

## Analysis

In the current implementation we tried to use stream so that we don't need to load the entire file in memory nor in file system.

However, `image-hash` package requires a buffer as its input. Even if we provide a file path to it, it will read the entire file into memory (then send to JPEG decoder) anyway. Therefore, it is inevitable that we put the entire file in memory.

## Proposed fix

This PR downloads the entire file from `mediaUrl` into a buffer and then pass to image-hash.

We set a max limit for the downloaded file (5MB for now) so that the API server will not run out of memory when someone send us a super large file. If a file bigger than the limit is provided, `CreateMediaArticle` will fail.


