### PR TITLE
Add articleReply filter to ListArticles

### DIFF
--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -167,7 +167,7 @@ export default {
     if (filter.articleReply) {
       articleReplyFilterQueries.push({
         terms: {
-          status:
+          'articleReplies.status':
             filter.articleReply.statuses || DEFAULT_ARTICLE_REPLY_STATUSES,
         },
       });
@@ -191,7 +191,7 @@ export default {
       filterQueries.push({
         nested: {
           path: 'articleReplies',
-          filter: {
+          query: {
             bool: {
               must: articleReplyFilterQueries,
             },

--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -188,7 +188,7 @@ export default {
         });
       }
 
-      shouldQueries.push({
+      filterQueries.push({
         nested: {
           path: 'articleReplies',
           filter: {

--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -19,12 +19,19 @@ import {
   getRangeFieldParamFromArithmeticExpression,
   createCommonListFilter,
   attachCommonListFilter,
+  DEFAULT_ARTICLE_REPLY_STATUSES,
 } from 'graphql/util';
 import scrapUrls from 'util/scrapUrls';
 import ReplyTypeEnum from 'graphql/models/ReplyTypeEnum';
 import ArticleTypeEnum from 'graphql/models/ArticleTypeEnum';
+import ArticleReplyStatusEnum from 'graphql/models/ArticleReplyStatusEnum';
 
 import { ArticleConnection } from 'graphql/models/Article';
+
+const {
+  ids: dontcare, // eslint-disable-line no-unused-vars
+  ...articleReplyCommonFilterArgs
+} = createCommonListFilter('articleReplies');
 
 export default {
   args: {
@@ -59,7 +66,7 @@ export default {
         repliedAt: {
           type: timeRangeInput,
           description:
-            'List only the articles that were replied between the specific time range.',
+            '[Deprecated] use articleReply filter instead. List only the articles that were replied between the specific time range.',
         },
         fromUserOfArticleId: {
           type: GraphQLString,
@@ -96,7 +103,8 @@ export default {
         },
         replyTypes: {
           type: new GraphQLList(ReplyTypeEnum),
-          description: 'List the articles with replies of certain types',
+          description:
+            '[Deprecated] use articleReply filter instead. List the articles with replies of certain types',
         },
         articleTypes: {
           type: new GraphQLList(ArticleTypeEnum),
@@ -105,6 +113,26 @@ export default {
         mediaUrl: {
           type: GraphQLString,
           description: 'Show the media article similar to the input url',
+        },
+        articleReply: {
+          description:
+            'Show articles with article replies matching this criteria',
+          type: new GraphQLInputObjectType({
+            name: 'ArticleReplyFilterInput',
+            fields: {
+              ...articleReplyCommonFilterArgs,
+              statuses: {
+                type: new GraphQLList(
+                  new GraphQLNonNull(ArticleReplyStatusEnum)
+                ),
+                defaultValue: DEFAULT_ARTICLE_REPLY_STATUSES,
+              },
+
+              replyTypes: {
+                tupe: new GraphQLList(ReplyTypeEnum),
+              },
+            },
+          }),
         },
       }),
     },
@@ -117,6 +145,7 @@ export default {
         'replyCount',
         'lastRequestedAt',
         'lastRepliedAt',
+        'lastMatchingArticleReplyCreatedAt',
       ]),
     },
     ...pagingArgs,
@@ -126,6 +155,51 @@ export default {
     { filter = {}, orderBy = [], ...otherParams },
     { loaders, userId, appId }
   ) {
+    // Collecting queries that will be used in bool queries later
+    const mustQueries = [];
+    const shouldQueries = []; // Affects scores
+    const filterQueries = []; // Not affects scores
+    const mustNotQueries = [];
+
+    // Setup article reply filter, which may be used in sort
+    //
+    const articleReplyFilterQueries = [];
+    if (filter.articleReply) {
+      articleReplyFilterQueries.push({
+        terms: {
+          status:
+            filter.articleReply.statuses || DEFAULT_ARTICLE_REPLY_STATUSES,
+        },
+      });
+
+      attachCommonListFilter(
+        articleReplyFilterQueries,
+        filter.articleReply,
+        userId,
+        appId,
+        'articleReplies.'
+      );
+
+      if (filter.articleReply.replyTypes) {
+        articleReplyFilterQueries.push({
+          terms: {
+            'articleReplies.replyType': filter.articleReply.replyTypes,
+          },
+        });
+      }
+
+      shouldQueries.push({
+        nested: {
+          path: 'articleReplies',
+          filter: {
+            bool: {
+              must: articleReplyFilterQueries,
+            },
+          },
+        },
+      });
+    }
+
     const body = {
       sort: getSortArgs(orderBy, {
         replyCount: o => ({ normalArticleReplyCount: { order: o } }),
@@ -143,15 +217,23 @@ export default {
             },
           },
         }),
+        lastMatchingArticleReplyCreatedAt: o => ({
+          'articleReplies.createdAt': {
+            order: o,
+            mode: 'max',
+            nested: {
+              path: 'articleReplies',
+              filter: {
+                bool: {
+                  must: articleReplyFilterQueries,
+                },
+              },
+            },
+          },
+        }),
       }),
       track_scores: true, // for _score sorting
     };
-
-    // Collecting queries that will be used in bool queries later
-    const mustQueries = [];
-    const shouldQueries = []; // Affects scores
-    const filterQueries = []; // Not affects scores
-    const mustNotQueries = [];
 
     attachCommonListFilter(filterQueries, filter, userId, appId);
 

--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -129,7 +129,7 @@ export default {
               },
 
               replyTypes: {
-                tupe: new GraphQLList(ReplyTypeEnum),
+                type: new GraphQLList(ReplyTypeEnum),
               },
             },
           }),

--- a/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
+++ b/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
@@ -11,6 +11,8 @@ export default {
         status: 'NORMAL',
         positiveFeedbackCount: 1,
         negativeFeedbackCount: 0,
+        userId: 'user1',
+        appId: 'app1',
       },
       {
         replyId: 'bar2',
@@ -19,6 +21,8 @@ export default {
         status: 'DELETED',
         positiveFeedbackCount: 0,
         negativeFeedbackCount: 0,
+        userId: 'user2',
+        appId: 'app1',
       },
       {
         replyId: 'bar4',
@@ -27,6 +31,8 @@ export default {
         status: 'DELETED',
         positiveFeedbackCount: 0,
         negativeFeedbackCount: 0,
+        userId: 'user1',
+        appId: 'app2',
       },
       {
         replyId: 'bar3',
@@ -35,6 +41,8 @@ export default {
         status: 'DELETED',
         positiveFeedbackCount: 0,
         negativeFeedbackCount: 1,
+        userId: 'user2',
+        appId: 'app2',
       },
       {
         replyId: 'bar5',
@@ -43,6 +51,8 @@ export default {
         status: 'BLOCKED',
         positiveFeedbackCount: 0,
         negativeFeedbackCount: 1,
+        userId: 'blocked-user',
+        appId: 'app1',
       },
     ],
     normalArticleReplyCount: 1,

--- a/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
+++ b/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
@@ -96,6 +96,78 @@ describe('GetReplyAndGetArticle', () => {
           }
         `({}, { userId: 'fakeUser', appId: 'LINE' })
       ).toMatchSnapshot();
+
+      // Test articleReplies's common filters
+      expect(
+        await gql`
+          {
+            GetArticle(id: "foo") {
+              user1Replies: articleReplies(
+                statuses: [NORMAL, DELETED]
+                userId: "user1"
+              ) {
+                replyId
+                userId
+                appId
+              }
+              app1Replies: articleReplies(
+                statuses: [NORMAL, DELETED]
+                appId: "app1"
+              ) {
+                replyId
+                userId
+                appId
+              }
+              selfOnlyReplies: articleReplies(
+                statuses: [NORMAL, DELETED]
+                selfOnly: true
+              ) {
+                replyId
+                userId
+                appId
+              }
+            }
+          }
+        `({}, { userId: 'user2', appId: 'app2' })
+      ).toMatchInlineSnapshot(`
+        Object {
+          "data": Object {
+            "GetArticle": Object {
+              "app1Replies": Array [
+                Object {
+                  "appId": "app1",
+                  "replyId": "bar2",
+                  "userId": "user2",
+                },
+                Object {
+                  "appId": "app1",
+                  "replyId": "bar",
+                  "userId": "user1",
+                },
+              ],
+              "selfOnlyReplies": Array [
+                Object {
+                  "appId": "app2",
+                  "replyId": "bar3",
+                  "userId": "user2",
+                },
+              ],
+              "user1Replies": Array [
+                Object {
+                  "appId": "app2",
+                  "replyId": "bar4",
+                  "userId": "user1",
+                },
+                Object {
+                  "appId": "app1",
+                  "replyId": "bar",
+                  "userId": "user1",
+                },
+              ],
+            },
+          },
+        }
+      `);
     });
 
     it('should return empty articleReply when there is none', async () => {

--- a/src/graphql/queries/__tests__/ListArticles.js
+++ b/src/graphql/queries/__tests__/ListArticles.js
@@ -92,6 +92,72 @@ describe('ListArticles', () => {
         }
       `()
     ).toMatchSnapshot('by lastRepliedAt DESC');
+
+    // Should be identical to 'by lastRepliedAt DESC' snapshot,
+    // but excludes articles without any article replies
+    expect(
+      (await gql`
+        {
+          ListArticles(
+            filter: { articleReply: { statuses: [NORMAL] } }
+            orderBy: [{ lastMatchingArticleReplyCreatedAt: DESC }]
+          ) {
+            edges {
+              node {
+                id
+                articleReplies {
+                  createdAt
+                }
+              }
+            }
+          }
+        }
+      `()).data.ListArticles
+    ).toMatchInlineSnapshot(`
+      Object {
+        "edges": Array [
+          Object {
+            "node": Object {
+              "articleReplies": Array [
+                Object {
+                  "createdAt": "2020-02-11T15:11:04.472Z",
+                },
+                Object {
+                  "createdAt": "2020-02-09T15:11:04.472Z",
+                },
+                Object {
+                  "createdAt": "2020-02-10T15:11:04.472Z",
+                },
+              ],
+              "id": "listArticleTest4",
+            },
+          },
+          Object {
+            "node": Object {
+              "articleReplies": Array [
+                Object {
+                  "createdAt": "2020-02-09T15:11:04.472Z",
+                },
+              ],
+              "id": "listArticleTest2",
+            },
+          },
+          Object {
+            "node": Object {
+              "articleReplies": Array [
+                Object {
+                  "createdAt": "2020-02-08T15:11:04.472Z",
+                },
+                Object {
+                  "createdAt": "2020-02-05T14:41:19.044Z",
+                },
+              ],
+              "id": "listArticleTest1",
+            },
+          },
+        ],
+      }
+    `);
   });
 
   const testReplyCount = async expression => {
@@ -400,6 +466,128 @@ describe('ListArticles', () => {
         }
       `()
     ).toMatchSnapshot('between 2020-02-04 and 2020-02-06');
+  });
+
+  it('filters by articleReplies filter', async () => {
+    // This should be identical to "earlier or equal to 2020-02-06" snapshot
+    expect(
+      (await gql`
+        {
+          ListArticles(
+            filter: {
+              articleReply: { createdAt: { GT: "2020-02-06T00:00:00.000Z" } }
+            }
+          ) {
+            edges {
+              node {
+                id
+                articleReplies {
+                  createdAt
+                }
+              }
+            }
+          }
+        }
+      `()).data.ListArticles
+    ).toMatchInlineSnapshot(`
+      Object {
+        "edges": Array [
+          Object {
+            "node": Object {
+              "articleReplies": Array [
+                Object {
+                  "createdAt": "2020-02-11T15:11:04.472Z",
+                },
+                Object {
+                  "createdAt": "2020-02-09T15:11:04.472Z",
+                },
+                Object {
+                  "createdAt": "2020-02-10T15:11:04.472Z",
+                },
+              ],
+              "id": "listArticleTest4",
+            },
+          },
+          Object {
+            "node": Object {
+              "articleReplies": Array [
+                Object {
+                  "createdAt": "2020-02-09T15:11:04.472Z",
+                },
+              ],
+              "id": "listArticleTest2",
+            },
+          },
+          Object {
+            "node": Object {
+              "articleReplies": Array [
+                Object {
+                  "createdAt": "2020-02-08T15:11:04.472Z",
+                },
+                Object {
+                  "createdAt": "2020-02-05T14:41:19.044Z",
+                },
+              ],
+              "id": "listArticleTest1",
+            },
+          },
+        ],
+      }
+    `);
+
+    // Should be identical to replied with NOT_RUMOR and OPINIONATED snapshot
+    expect(
+      (await gql`
+        {
+          ListArticles(
+            filter: { articleReply: { replyTypes: [NOT_RUMOR, OPINIONATED] } }
+          ) {
+            edges {
+              node {
+                id
+                articleReplies {
+                  replyType
+                }
+              }
+            }
+          }
+        }
+      `()).data.ListArticles
+    ).toMatchInlineSnapshot(`
+      Object {
+        "edges": Array [
+          Object {
+            "node": Object {
+              "articleReplies": Array [
+                Object {
+                  "replyType": "OPINIONATED",
+                },
+                Object {
+                  "replyType": "NOT_ARTICLE",
+                },
+                Object {
+                  "replyType": "NOT_ARTICLE",
+                },
+              ],
+              "id": "listArticleTest4",
+            },
+          },
+          Object {
+            "node": Object {
+              "articleReplies": Array [
+                Object {
+                  "replyType": "NOT_RUMOR",
+                },
+                Object {
+                  "replyType": "NOT_ARTICLE",
+                },
+              ],
+              "id": "listArticleTest1",
+            },
+          },
+        ],
+      }
+    `);
   });
 
   it('filters by mixed query', async () => {

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -470,27 +470,39 @@ export function createCommonListFilter(pluralEntityName) {
  * @param {object} filter - args.filter in resolver
  * @param {string} userId - userId for the currently logged in user
  * @param {string} appid - appId for the currently logged in user
+ * @param {string?} fieldPrefix - If given, filters fields will be prefixed with the given string. Disables handling of `ids`.
  */
-export function attachCommonListFilter(filterQueries, filter, userId, appId) {
+export function attachCommonListFilter(
+  filterQueries,
+  filter,
+  userId,
+  appId,
+  fieldPrefix = ''
+) {
   ['userId', 'appId'].forEach(field => {
     if (!filter[field]) return;
-    filterQueries.push({ term: { [field]: filter[field] } });
+    filterQueries.push({ term: { [`${fieldPrefix}${field}`]: filter[field] } });
   });
 
   if (filter.createdAt) {
     filterQueries.push({
       range: {
-        createdAt: getRangeFieldParamFromArithmeticExpression(filter.createdAt),
+        [`${fieldPrefix}createdAt`]: getRangeFieldParamFromArithmeticExpression(
+          filter.createdAt
+        ),
       },
     });
   }
 
-  if (filter.ids) {
+  if (!fieldPrefix && filter.ids) {
     filterQueries.push({ ids: { values: filter.ids } });
   }
 
   if (filter.selfOnly) {
     if (!userId) throw new Error('selfOnly can be set only after log in');
-    filterQueries.push({ term: { userId } }, { term: { appId } });
+    filterQueries.push(
+      { term: { [`${fieldPrefix}userId`]: userId } },
+      { term: { [`${fieldPrefix}appId`]: appId } }
+    );
   }
 }


### PR DESCRIPTION
According to [meeting note](https://g0v.hackmd.io/_HXxDu6OQPaK08WFwOshtg#%E7%B0%A1%E5%8C%96%E4%BA%8C%E6%AC%A1%E8%A9%90%E9%A8%99%E5%85%AC%E5%91%8A%E6%B5%81%E7%A8%8B), it would be great to have an advanced filter for article replies to track down blocked user's activities. It would also help profile page, when listing replies of the current user.

This PR adds filters to the following fields:

- `Query.ListArticles`
    - Adds `articleReply.appId / userId / createdAt / selfOnly` filter so that `ListArticles` returns only articles with article replies matching the specified filter.
    - Adds `lastMatchingArticleReplyCreatedAt` sorts articles using the latest `articleReply`'s creation time matching the above filter
- `Article.articleReplies`
    - Adds `appId`, `userId`, `selfOnly` filters to filter article replies on server-side in application-level