### PR TITLE
Record feedback target author and allow filtering by feedback authors

### DIFF
--- a/src/graphql/models/ArticleReplyFeedback.js
+++ b/src/graphql/models/ArticleReplyFeedback.js
@@ -29,6 +29,15 @@ export default new GraphQLObjectType({
     userId: { type: GraphQLString },
     appId: { type: GraphQLString },
 
+    replyUserId: {
+      description: "User ID of the reply's author",
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    articleReplyUserId: {
+      description: "User ID of the article-reply's author",
+      type: new GraphQLNonNull(GraphQLString),
+    },
+
     comment: { type: GraphQLString },
 
     createdAt: { type: GraphQLString },

--- a/src/graphql/mutations/__fixtures__/CreateOrUpdateArticleReplyFeedback.js
+++ b/src/graphql/mutations/__fixtures__/CreateOrUpdateArticleReplyFeedback.js
@@ -11,10 +11,14 @@ export default {
     articleReplies: [
       {
         replyId: 'reply1',
+        userId: 'articleReply user ID',
         positiveFeedbackCount: 11,
         negativeFeedbackCount: 0,
       },
     ],
+  },
+  '/replies/doc/reply1': {
+    userId: 'reply user ID',
   },
   ...generateEntry({
     score: 1,

--- a/src/graphql/mutations/__tests__/CreateOrUpdateArticleReplyFeedback.js
+++ b/src/graphql/mutations/__tests__/CreateOrUpdateArticleReplyFeedback.js
@@ -67,9 +67,11 @@ describe('CreateOrUpdateArticleReplyFeedback', () => {
       Object {
         "appId": "test",
         "articleId": "article1",
+        "articleReplyUserId": "articleReply user ID",
         "comment": "comment1",
         "createdAt": "2017-01-28T08:45:57.011Z",
         "replyId": "reply1",
+        "replyUserId": "reply user ID",
         "score": 1,
         "status": "NORMAL",
         "updatedAt": "2017-01-28T08:45:57.011Z",
@@ -88,6 +90,7 @@ describe('CreateOrUpdateArticleReplyFeedback', () => {
           "negativeFeedbackCount": 0,
           "positiveFeedbackCount": 12,
           "replyId": "reply1",
+          "userId": "articleReply user ID",
         },
       ]
     `);
@@ -225,9 +228,11 @@ describe('CreateOrUpdateArticleReplyFeedback', () => {
       Object {
         "appId": "test",
         "articleId": "article1",
+        "articleReplyUserId": "articleReply user ID",
         "comment": "ads content",
         "createdAt": "2017-01-28T08:45:57.011Z",
         "replyId": "reply1",
+        "replyUserId": "reply user ID",
         "score": 1,
         "status": "BLOCKED",
         "updatedAt": "2017-01-28T08:45:57.011Z",
@@ -246,6 +251,7 @@ describe('CreateOrUpdateArticleReplyFeedback', () => {
           "negativeFeedbackCount": 0,
           "positiveFeedbackCount": 11,
           "replyId": "reply1",
+          "userId": "articleReply user ID",
         },
       ]
     `);

--- a/src/graphql/queries/ListArticleReplyFeedbacks.js
+++ b/src/graphql/queries/ListArticleReplyFeedbacks.js
@@ -59,6 +59,11 @@ export default {
           description:
             'List only the feedbacks to the article-replies created by this user ID',
         },
+        authorId: {
+          type: GraphQLString,
+          description:
+            'List only the feedbacks whose `replyUserId` *or* `articleReplyUserId` is this user ID',
+        },
       }),
     },
     orderBy: {
@@ -131,6 +136,17 @@ export default {
           updatedAt: getRangeFieldParamFromArithmeticExpression(
             filter.updatedAt
           ),
+        },
+      });
+    }
+
+    if (filter.authorId) {
+      filterQueries.push({
+        bool: {
+          should: [
+            { term: { replyUserId: filter.authorId } },
+            { term: { articleReplyUserId: filter.authorId } },
+          ],
         },
       });
     }

--- a/src/graphql/queries/ListArticleReplyFeedbacks.js
+++ b/src/graphql/queries/ListArticleReplyFeedbacks.js
@@ -49,6 +49,16 @@ export default {
           description:
             'List only the article reply feedbacks with the selected statuses',
         },
+        replyUserId: {
+          type: GraphQLString,
+          description:
+            'List only the feedbacks to the replies created by this user ID',
+        },
+        articleReplyUserId: {
+          type: GraphQLString,
+          description:
+            'List only the feedbacks to the article-replies created by this user ID',
+        },
       }),
     },
     orderBy: {
@@ -87,10 +97,12 @@ export default {
 
     attachCommonListFilter(filterQueries, filter, userId, appId);
 
-    ['articleId', 'replyId'].forEach(field => {
-      if (!filter[field]) return;
-      filterQueries.push({ term: { [field]: filter[field] } });
-    });
+    ['articleId', 'replyId', 'replyUserId', 'articleReplyUserId'].forEach(
+      field => {
+        if (!filter[field]) return;
+        filterQueries.push({ term: { [field]: filter[field] } });
+      }
+    );
 
     if (filter.moreLikeThis) {
       shouldQueries.push({

--- a/src/graphql/queries/__fixtures__/ListArticleReplyFeedbacks.js
+++ b/src/graphql/queries/__fixtures__/ListArticleReplyFeedbacks.js
@@ -28,6 +28,8 @@ export default {
     status: 'NORMAL',
     createdAt: '2020-03-06T00:00:00.000Z',
     updatedAt: '2020-04-06T00:00:00.000Z',
+    replyUserId: 'user2',
+    articleReplyUserId: 'user3',
   },
   '/articlereplyfeedbacks/doc/f2': {
     userId: 'user1',
@@ -39,6 +41,8 @@ export default {
     comment: '武漢肺炎',
     createdAt: '2020-02-06T00:00:00.000Z',
     updatedAt: '2020-05-06T00:00:00.000Z',
+    replyUserId: 'user3',
+    articleReplyUserId: 'user2',
   },
   '/articlereplyfeedbacks/doc/f3': {
     userId: 'user2',
@@ -50,5 +54,7 @@ export default {
     comment: 'Thank you for info regarding COVID19.',
     createdAt: '2020-04-06T00:00:00.000Z',
     updatedAt: '2020-06-06T00:00:00.000Z',
+    replyUserId: 'user4',
+    articleReplyUserId: 'user4',
   },
 };

--- a/src/graphql/queries/__tests__/ListArticleReplyFeedbacks.js
+++ b/src/graphql/queries/__tests__/ListArticleReplyFeedbacks.js
@@ -131,6 +131,36 @@ describe('ListArticleReplyFeedbacks', () => {
         }
       `()
     ).toMatchSnapshot('by replyId: r2');
+    expect(
+      await gql`
+        {
+          ListArticleReplyFeedbacks(filter: { replyUserId: "user2" }) {
+            edges {
+              node {
+                id
+                replyUserId
+              }
+            }
+            totalCount
+          }
+        }
+      `()
+    ).toMatchSnapshot('by replyUserId: user2');
+    expect(
+      await gql`
+        {
+          ListArticleReplyFeedbacks(filter: { articleReplyUserId: "user3" }) {
+            edges {
+              node {
+                id
+                articleReplyUserId
+              }
+            }
+            totalCount
+          }
+        }
+      `()
+    ).toMatchSnapshot('by articleReplyUserId: user3');
   });
 
   it('filters by moreLikeThis', async () => {

--- a/src/graphql/queries/__tests__/ListArticleReplyFeedbacks.js
+++ b/src/graphql/queries/__tests__/ListArticleReplyFeedbacks.js
@@ -161,6 +161,23 @@ describe('ListArticleReplyFeedbacks', () => {
         }
       `()
     ).toMatchSnapshot('by articleReplyUserId: user3');
+
+    expect(
+      await gql`
+        {
+          ListArticleReplyFeedbacks(filter: { authorId: "user2" }) {
+            edges {
+              node {
+                id
+                replyUserId
+                articleReplyUserId
+              }
+            }
+            totalCount
+          }
+        }
+      `()
+    ).toMatchSnapshot('by replyUserId=user2 OR articleReplyUserId=user2');
   });
 
   it('filters by moreLikeThis', async () => {

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticleReplyFeedbacks.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticleReplyFeedbacks.js.snap
@@ -120,6 +120,32 @@ Object {
 }
 `;
 
+exports[`ListArticleReplyFeedbacks filters by DB fields xxId: by replyUserId=user2 OR articleReplyUserId=user2 1`] = `
+Object {
+  "data": Object {
+    "ListArticleReplyFeedbacks": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "articleReplyUserId": "user2",
+            "id": "f2",
+            "replyUserId": "user3",
+          },
+        },
+        Object {
+          "node": Object {
+            "articleReplyUserId": "user3",
+            "id": "f1",
+            "replyUserId": "user2",
+          },
+        },
+      ],
+      "totalCount": 2,
+    },
+  },
+}
+`;
+
 exports[`ListArticleReplyFeedbacks filters by DB fields xxId: by userId: user1 1`] = `
 Object {
   "data": Object {

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticleReplyFeedbacks.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticleReplyFeedbacks.js.snap
@@ -54,6 +54,24 @@ Object {
 }
 `;
 
+exports[`ListArticleReplyFeedbacks filters by DB fields xxId: by articleReplyUserId: user3 1`] = `
+Object {
+  "data": Object {
+    "ListArticleReplyFeedbacks": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "articleReplyUserId": "user3",
+            "id": "f1",
+          },
+        },
+      ],
+      "totalCount": 1,
+    },
+  },
+}
+`;
+
 exports[`ListArticleReplyFeedbacks filters by DB fields xxId: by replyId: r2 1`] = `
 Object {
   "data": Object {
@@ -79,6 +97,24 @@ Object {
         },
       ],
       "totalCount": 2,
+    },
+  },
+}
+`;
+
+exports[`ListArticleReplyFeedbacks filters by DB fields xxId: by replyUserId: user2 1`] = `
+Object {
+  "data": Object {
+    "ListArticleReplyFeedbacks": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "f1",
+            "replyUserId": "user2",
+          },
+        },
+      ],
+      "totalCount": 1,
     },
   },
 }


### PR DESCRIPTION
Fixes #280 

- Update schema and expose `replyUserId`, `articleReplyUserId` for `ArticleReplyFeedback`
- `CreateOrUpdateArticleReplyFeedback` writes `replyUserId` and `articleReplyUserId` on creation
- `ListArticleReplyFeedback` can filter by `replyUserId`, `articleReplyUserId` or `authorId`
    - `authorId`: lists feedbacks whose `replyUserId` is the specified ID, _or_ whose `articleReplyUserId` is the specified ID
- Migration script filling up `replyUserId` and `articleReplyUserId` for existing `ArticleReplyFeedback` (not checked in, just for copy & paste use)