### PR TITLE
Fix ArticleType's attachmentUrl and CreateOrUpdateArticleReplyFeedback's articleReplyUserId

### DIFF
--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -368,6 +368,8 @@ const Article = new GraphQLObjectType({
       type: GraphQLString,
       description: 'Attachment of this article',
       async resolve({ attachmentHash }) {
+        if (!attachmentHash) return null;
+
         const info = await mediaManager.getInfo(attachmentHash);
         return info.url;
       },

--- a/src/graphql/mutations/CreateOrUpdateArticleReplyFeedback.js
+++ b/src/graphql/mutations/CreateOrUpdateArticleReplyFeedback.js
@@ -146,15 +146,20 @@ export default {
       // Fill in reply & article reply author ID
       //
 
-      const { userId: replyUserId } = await loaders.docLoader.load({
-        index: 'replies',
-        id: replyId,
-      });
+      const [
+        { userId: replyUserId },
+        article,
+      ] = await loaders.docLoader.loadMany([
+        {
+          index: 'replies',
+          id: replyId,
+        },
+        {
+          index: 'articles',
+          id: articleId,
+        },
+      ]);
 
-      const article = await loaders.docLoader.load({
-        index: 'articles',
-        id: articleId,
-      });
       const { userId: articleReplyUserId } = article.articleReplies.find(
         ar => ar.replyId === replyId
       );

--- a/src/graphql/mutations/CreateOrUpdateArticleReplyFeedback.js
+++ b/src/graphql/mutations/CreateOrUpdateArticleReplyFeedback.js
@@ -156,7 +156,7 @@ export default {
         id: articleId,
       });
       const { userId: articleReplyUserId } = article.articleReplies.find(
-        ar => (ar.replyId = replyId)
+        ar => ar.replyId === replyId
       );
 
       await client.update({

--- a/src/graphql/mutations/__fixtures__/CreateOrUpdateArticleReplyFeedback.js
+++ b/src/graphql/mutations/__fixtures__/CreateOrUpdateArticleReplyFeedback.js
@@ -10,6 +10,12 @@ export default {
   '/articles/doc/article1': {
     articleReplies: [
       {
+        replyId: 'reply2',
+        userId: 'another articleReply user ID',
+        positiveFeedbackCount: 0,
+        negativeFeedbackCount: 0,
+      },
+      {
         replyId: 'reply1',
         userId: 'articleReply user ID',
         positiveFeedbackCount: 11,

--- a/src/graphql/mutations/__tests__/CreateOrUpdateArticleReplyFeedback.js
+++ b/src/graphql/mutations/__tests__/CreateOrUpdateArticleReplyFeedback.js
@@ -88,6 +88,12 @@ describe('CreateOrUpdateArticleReplyFeedback', () => {
       Array [
         Object {
           "negativeFeedbackCount": 0,
+          "positiveFeedbackCount": 0,
+          "replyId": "reply2",
+          "userId": "another articleReply user ID",
+        },
+        Object {
+          "negativeFeedbackCount": 0,
           "positiveFeedbackCount": 12,
           "replyId": "reply1",
           "userId": "articleReply user ID",
@@ -247,6 +253,12 @@ describe('CreateOrUpdateArticleReplyFeedback', () => {
     });
     expect(article._source.articleReplies).toMatchInlineSnapshot(`
       Array [
+        Object {
+          "negativeFeedbackCount": 0,
+          "positiveFeedbackCount": 0,
+          "replyId": "reply2",
+          "userId": "another articleReply user ID",
+        },
         Object {
           "negativeFeedbackCount": 0,
           "positiveFeedbackCount": 11,

--- a/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
+++ b/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
@@ -44,6 +44,8 @@ describe('GetReplyAndGetArticle', () => {
                 }
               }
               requestedForReply
+              attachmentHash
+              attachmentUrl
             }
           }
         `({}, { user: { id: 'fakeUser', appId: 'LINE' } })

--- a/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
@@ -280,6 +280,8 @@ Object {
           "updatedAt": "2015-01-02T12:10:30Z",
         },
       ],
+      "attachmentHash": null,
+      "attachmentUrl": null,
       "references": Array [
         Object {
           "type": "LINE",


### PR DESCRIPTION
## Bugfix 1: ArticleType's `attachmentUrl` field throws error when `attachmentHash` is empty
The bug was introduced in #284 .

Querying `ArticleType`'s `attachmentUrl` will trigger `Cannot read properties of undefined (reading 'split')` error.

<img width="1440" alt="圖片" src="https://user-images.githubusercontent.com/108608/175766904-0971cfe6-7706-4fcf-abab-98c124af4248.png">

The root cause is that for non-image articles, `attachmentHash` is null. However, we send `null` to `MediaManager` to generate URL for `attachmentUrl` field.

This PR:
- Returns null for `attachmentUrl` if `attachmentHash` is null
- Introduces a test case that will fail if this PR is not implemented

## Bugfix 2: `CreateOrUpdateArticleReplyFeedback` records wrong `articleReplyUserId` on feedback doc

In the image below, the article reply feedback for article `2889dua0k41ro` and reply `sKR1hn0BnX5-aOa4S29I` has its `articleReplyUserId` being `AWA_PbObyCdS-nWhukq-`; however, according to the article data, the article reply is actually created by user `AVqVwjqQyrDaTqlmmp_a`.
![圖片](https://user-images.githubusercontent.com/108608/175776602-5730e187-b789-4fd1-884c-664092557480.png)

This PR
- Fixes the typo in the logic that wrongly grabs the first article reply's author as `articleReplyUserId`
- Adjust unit test fixture to reproduce the bug and proof that it's fixed

This PR is deployed to staging on 6/25.