### PR TITLE
fetchStatsFromGA script now warns about sampled data

### DIFF
--- a/src/scripts/fetchStatsFromGA.js
+++ b/src/scripts/fetchStatsFromGA.js
@@ -148,6 +148,36 @@ const requestBodyBuilder = function(sourceType, docType, pageToken, params) {
 };
 
 /**
+ *
+ * @param {Object} report - The report data resolved by analyticsreporting.reports.batchGet()
+ */
+/* istanbul ignore next */
+function warnIfReportIsSampled(report) {
+  if (!report.data.samplingSpaceSizes && !report.data.samplesReadCounts) return;
+
+  console.warn(
+    '-------------------------------------------------------------------------------'
+  );
+  console.warn(
+    '⚠️ Note: The result contains sampled data, thus the numbers may be inaccurate. ⚠️'
+  );
+  console.warn(
+    `${
+      report.data.samplesReadCounts?.[0]
+    } samples are read out of the sample space of ${
+      report.data.samplingSpaceSizes?.[0]
+    }.`
+  );
+  console.warn('Please consider using a smaller date range.');
+  console.warn(
+    'Document about data sampling: https://support.google.com/analytics/answer/2637192'
+  );
+  console.warn(
+    '-------------------------------------------------------------------------------'
+  );
+}
+
+/**
  * Given a sourceType, fetch stats for all doc types from startDate to endDate (inclusive).
 
  * @param {string} sourceType
@@ -187,12 +217,14 @@ const fetchReports = async function(sourceType, pageTokens = {}, params) {
       reportRequests,
     },
   });
+
   const reports = res.data.reports;
   let results = {};
   let hasMore = false;
 
   requestDocTypes.forEach((docType, i) => {
     let report = reports[i];
+    warnIfReportIsSampled(report);
     const rows = report.data.rows;
     if (rows) {
       console.log(
@@ -265,6 +297,7 @@ async function* getLiffReportEntries(docType, params) {
     });
 
     const [report] = res.data.reports;
+    warnIfReportIsSampled(report);
     const rows = report.data.rows ?? [];
 
     console.log(


### PR DESCRIPTION
When back filling old analytics data, we found that the fetched LIFF stats are inconsistent with the numbers on Google Analytics.

We can reproduce this on local machine, and found that the inaccuracy only happens when the data is sampled:
https://developers.google.com/analytics/devguides/reporting/core/v4/basics#sampling

If we specify a shorter date range when running the script, the inconsistency will be gone.

This PR adds a warning message when sampled data is detected from the Google Analytics Reporting API response.

<img width="847" alt="圖片" src="https://user-images.githubusercontent.com/108608/183285758-e32e57a5-6533-48d3-96ad-c0e4e5b6bfbf.png">

Sampling should only happens when we manually back-fill the data. The hourly cron job should not have that much of data that triggers Google Analytics samplng.