### PR TITLE
Add status to article

### DIFF
--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -37,6 +37,7 @@ import ArticleReplyStatusEnum from './ArticleReplyStatusEnum';
 import ArticleReply from './ArticleReply';
 import ArticleCategoryStatusEnum from './ArticleCategoryStatusEnum';
 import ReplyRequestStatusEnum from './ReplyRequestStatusEnum';
+import ArticleStatusEnum from './ArticleStatusEnum';
 import ArticleCategory from './ArticleCategory';
 import Hyperlink from './Hyperlink';
 import ReplyRequest from './ReplyRequest';
@@ -60,6 +61,7 @@ const Article = new GraphQLObjectType({
     text: { type: GraphQLString },
     createdAt: { type: GraphQLString },
     updatedAt: { type: GraphQLString },
+    status: { type: new GraphQLNonNull(ReplyRequestStatusEnum) },
     references: { type: new GraphQLList(ArticleReference) },
     replyCount: {
       type: GraphQLInt,

--- a/src/graphql/models/ArticleStatusEnum.js
+++ b/src/graphql/models/ArticleStatusEnum.js
@@ -1,0 +1,14 @@
+import { GraphQLEnumType } from 'graphql';
+
+export default new GraphQLEnumType({
+  name: 'ArticleStatusEnum',
+  values: {
+    NORMAL: {
+      value: 'NORMAL',
+    },
+    BLOCKED: {
+      value: 'BLOCKED',
+      description: 'Created by a blocked user violating terms of use.',
+    },
+  },
+});

--- a/src/graphql/mutations/CreateArticle.js
+++ b/src/graphql/mutations/CreateArticle.js
@@ -87,6 +87,7 @@ async function createNewArticle({
         articleType: 'TEXT',
         attachmentUrl: '',
         attachmentHash: '',
+        status: 'NORMAL',
       },
     },
     refresh: 'true', // Make sure the data is indexed when we create ReplyRequest

--- a/src/graphql/mutations/CreateMediaArticle.js
+++ b/src/graphql/mutations/CreateMediaArticle.js
@@ -140,6 +140,7 @@ async function createNewMediaArticle({
       hyperlinks: [],
       articleType,
       attachmentHash,
+      status: 'NORMAL',
     },
   });
 

--- a/src/graphql/mutations/__tests__/CreateMediaArticle.js
+++ b/src/graphql/mutations/__tests__/CreateMediaArticle.js
@@ -96,6 +96,7 @@ describe('creation', () => {
           },
         ],
         "replyRequestCount": 1,
+        "status": "NORMAL",
         "tags": Array [],
         "text": "",
         "updatedAt": "2017-01-28T08:45:57.011Z",

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateArticle.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateArticle.js.snap
@@ -49,6 +49,7 @@ Object {
     },
   ],
   "replyRequestCount": 1,
+  "status": "NORMAL",
   "tags": Array [],
   "text": "FOO FOO http://foo.com/article/1",
   "updatedAt": "2017-01-28T08:45:57.011Z",

--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -19,9 +19,11 @@ import {
   getRangeFieldParamFromArithmeticExpression,
   createCommonListFilter,
   attachCommonListFilter,
+  DEFAULT_ARTICLE_STATUSES,
   DEFAULT_ARTICLE_REPLY_STATUSES,
 } from 'graphql/util';
 import scrapUrls from 'util/scrapUrls';
+import ArticleStatusEnum from 'graphql/models/ArticleStatusEnum';
 import ReplyTypeEnum from 'graphql/models/ReplyTypeEnum';
 import ArticleTypeEnum from 'graphql/models/ArticleTypeEnum';
 import ArticleReplyStatusEnum from 'graphql/models/ArticleReplyStatusEnum';
@@ -134,6 +136,11 @@ export default {
             },
           }),
         },
+        statuses: {
+          type: new GraphQLList(new GraphQLNonNull(ArticleStatusEnum)),
+          defaultValue: DEFAULT_ARTICLE_STATUSES,
+          description: 'Returns only articles with the specified statuses',
+        },
       }),
     },
     orderBy: {
@@ -158,7 +165,13 @@ export default {
     // Collecting queries that will be used in bool queries later
     const mustQueries = [];
     const shouldQueries = []; // Affects scores
-    const filterQueries = []; // Not affects scores
+    const filterQueries = [
+      {
+        terms: {
+          status: filter.statuses || DEFAULT_ARTICLE_STATUSES,
+        },
+      },
+    ]; // Not affects scores
     const mustNotQueries = [];
 
     // Setup article reply filter, which may be used in sort

--- a/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
+++ b/src/graphql/queries/__fixtures__/GetReplyAndArticle.js
@@ -82,6 +82,7 @@ export default {
         summary: 'summary summary',
       },
     ],
+    status: 'NORMAL',
   },
   '/articles/doc/foo2': {
     text: 'Lorum ipsum Lorum ipsum',
@@ -93,6 +94,7 @@ export default {
     ],
     normalArticleReplyCount: 1,
     references: [{ type: 'LINE' }],
+    status: 'NORMAL',
   },
   '/articles/doc/foo3': {
     text: 'Lorum ipsum Lorum ipsum Lorum ipsum',
@@ -114,17 +116,39 @@ export default {
         summary: 'summary',
       },
     ],
+    status: 'NORMAL',
+  },
+  // These should not appear in the related article of normal articles
+  //
+  '/articles/doc/blockedArticle1': {
+    text: 'Lorum ipsum ipsum',
+    articleReplies: [],
+    normalArticleReplyCount: 1,
+    references: [{ type: 'LINE' }],
+    hyperlinks: [],
+    status: 'BLOCKED',
+  },
+  '/articles/doc/blockedArticle2': {
+    text: 'Lorum lorum ipsum ipsum',
+    articleReplies: [],
+    normalArticleReplyCount: 1,
+    references: [{ type: 'LINE' }],
+    hyperlinks: [],
+    status: 'BLOCKED',
   },
   '/articles/doc/manyRequests': {
     text: 'Popular',
     replyRequestCount: 11,
+    status: 'NORMAL',
   },
   '/articles/doc/mediaArticle': {
     text: 'Lorum ipsum', // Transcript
     attachmentHash: 'hash-for-media-article',
+    status: 'NORMAL',
   },
   '/articles/doc/similarMediaArticle': {
     attachmentHash: 'hash-for-similar-media-article',
+    status: 'NORMAL',
   },
   '/replies/doc/bar': {
     text: 'bar',

--- a/src/graphql/queries/__fixtures__/ListArticles.js
+++ b/src/graphql/queries/__fixtures__/ListArticles.js
@@ -49,6 +49,7 @@ export default {
     attachmentUrl: '',
     attachmentHash: '',
     articleType: 'TEXT',
+    status: 'NORMAL',
   },
   '/articles/doc/listArticleTest2': {
     userId: 'user1',
@@ -107,6 +108,7 @@ export default {
     attachmentUrl: '',
     attachmentHash: '',
     articleType: 'TEXT',
+    status: 'NORMAL',
   },
   '/articles/doc/listArticleTest3': {
     userId: 'user2',
@@ -130,6 +132,7 @@ export default {
     attachmentUrl: '',
     attachmentHash: '',
     articleType: 'TEXT',
+    status: 'NORMAL',
   },
   '/articles/doc/listArticleTest4': {
     userId: 'user2',
@@ -198,6 +201,7 @@ export default {
     attachmentUrl: '',
     attachmentHash: '',
     articleType: 'TEXT',
+    status: 'NORMAL',
   },
   '/articles/doc/listArticleTest5': {
     userId: 'user1',
@@ -213,6 +217,7 @@ export default {
     attachmentUrl: 'http://foo/image.jpeg',
     attachmentHash: 'ffff8000',
     articleType: 'IMAGE',
+    status: 'NORMAL',
   },
   '/articles/doc/listArticleTest6': {
     userId: 'user1',
@@ -228,6 +233,7 @@ export default {
     attachmentUrl: 'http://foo/image2.jpeg',
     attachmentHash: 'ffff8001',
     articleType: 'IMAGE',
+    status: 'NORMAL',
   },
   '/articles/doc/listArticleTest7': {
     userId: 'user1',
@@ -243,6 +249,25 @@ export default {
     attachmentUrl: 'http://foo/audio.mp3',
     attachmentHash: 'ffff8002',
     articleType: 'AUDIO',
+    status: 'NORMAL',
+  },
+  // Blocked article, does not appear in ListArticles by default
+  //
+  '/articles/doc/blockedArticle': {
+    userId: 'malicious-user',
+    appId: 'app1',
+    replyRequestCount: 0,
+    normalArticleReplyCount: 0,
+    normalArticleCategoryCount: 0,
+    updatedAt: 1,
+    createdAt: '2020-02-10T00:00:00.000Z',
+    text: '這是一則二次詐騙訊息，由同一位 LINE 使用者不斷推送',
+    articleReplies: [],
+    articleCategories: [],
+    attachmentUrl: 'http://foo/audio.mp3',
+    attachmentHash: 'ffff8002',
+    articleType: 'TEXT',
+    status: 'BLOCKED',
   },
   '/categories/doc/category1': {
     title: '文言文',

--- a/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
+++ b/src/graphql/queries/__tests__/GetReplyAndGetArticle.js
@@ -324,6 +324,60 @@ describe('GetReplyAndGetArticle', () => {
       `);
     });
 
+    it('relatedArticle of blocked article can include both normal and blocked articles', async () => {
+      expect(
+        await gql`
+          {
+            GetArticle(id: "blockedArticle1") {
+              relatedArticles {
+                edges {
+                  node {
+                    id
+                  }
+                }
+              }
+            }
+          }
+        `()
+      ).toMatchInlineSnapshot(`
+        Object {
+          "data": Object {
+            "GetArticle": Object {
+              "relatedArticles": Object {
+                "edges": Array [
+                  Object {
+                    "node": Object {
+                      "id": "foo3",
+                    },
+                  },
+                  Object {
+                    "node": Object {
+                      "id": "foo2",
+                    },
+                  },
+                  Object {
+                    "node": Object {
+                      "id": "blockedArticle2",
+                    },
+                  },
+                  Object {
+                    "node": Object {
+                      "id": "mediaArticle",
+                    },
+                  },
+                  Object {
+                    "node": Object {
+                      "id": "foo",
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        }
+      `);
+    });
+
     it('feedbacks should work', async () => {
       expect(
         await gql`

--- a/src/graphql/queries/__tests__/ListArticles.js
+++ b/src/graphql/queries/__tests__/ListArticles.js
@@ -589,6 +589,38 @@ describe('ListArticles', () => {
     `);
   });
 
+  it('filters by status', async () => {
+    expect(
+      await gql`
+        {
+          ListArticles(filter: { statuses: [BLOCKED] }) {
+            edges {
+              node {
+                id
+              }
+            }
+            totalCount
+          }
+        }
+      `()
+    ).toMatchInlineSnapshot(`
+      Object {
+        "data": Object {
+          "ListArticles": Object {
+            "edges": Array [
+              Object {
+                "node": Object {
+                  "id": "blockedArticle",
+                },
+              },
+            ],
+            "totalCount": 1,
+          },
+        },
+      }
+    `);
+  });
+
   it('filters by mixed query', async () => {
     // Mixes 'should' and 'filter' query. At least 1 'should' must match.
     // Therefore, this query should only match 1 result instead of all that satisfies replyRequestCount: { GT: 0 }

--- a/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/GetReplyAndGetArticle.js.snap
@@ -135,25 +135,25 @@ Object {
             "score": 7.5,
           },
           Object {
-            "cursor": "WzAuNzQ0NTg4ODUsImZvbzMiXQ==",
+            "cursor": "WzAuNTQ2MTgxODYsImZvbzMiXQ==",
             "node": Object {
               "id": "foo3",
             },
-            "score": 0.74458885,
+            "score": 0.54618186,
           },
           Object {
-            "cursor": "WzAuNzIzMzE0OTQsImZvbzIiXQ==",
+            "cursor": "WzAuNTMwMzI5NiwiZm9vMiJd",
             "node": Object {
               "id": "foo2",
             },
-            "score": 0.72331494,
+            "score": 0.5303296,
           },
           Object {
-            "cursor": "WzAuNjY2MjExMSwiZm9vIl0=",
+            "cursor": "WzAuNDg3ODUxNywiZm9vIl0=",
             "node": Object {
               "id": "foo",
             },
-            "score": 0.6662111,
+            "score": 0.4878517,
           },
         ],
       },
@@ -169,20 +169,20 @@ Object {
       "relatedArticles": Object {
         "edges": Array [
           Object {
-            "cursor": "WzEuMTg0OTAyMywiZm9vMyJd",
+            "cursor": "WzAuOTg2NDk1MywiZm9vMyJd",
             "node": Object {
               "id": "foo3",
               "text": "Lorum ipsum Lorum ipsum Lorum ipsum",
             },
-            "score": 1.1849023,
+            "score": 0.9864953,
           },
           Object {
-            "cursor": "WzAuNzIzMzE0OTQsImZvbzIiXQ==",
+            "cursor": "WzAuNTMwMzI5NiwiZm9vMiJd",
             "node": Object {
               "id": "foo2",
               "text": "Lorum ipsum Lorum ipsum",
             },
-            "score": 0.72331494,
+            "score": 0.5303296,
           },
         ],
       },
@@ -198,7 +198,7 @@ Object {
       "relatedArticles": Object {
         "edges": Array [
           Object {
-            "cursor": "WzEuMTg0OTAyMywiZm9vMyJd",
+            "cursor": "WzAuOTg2NDk1MywiZm9vMyJd",
             "highlight": Object {
               "hyperlinks": Array [
                 Object {
@@ -212,10 +212,10 @@ Object {
             "node": Object {
               "id": "foo3",
             },
-            "score": 1.1849023,
+            "score": 0.9864953,
           },
           Object {
-            "cursor": "WzAuNzIzMzE0OTQsImZvbzIiXQ==",
+            "cursor": "WzAuNTMwMzI5NiwiZm9vMiJd",
             "highlight": Object {
               "hyperlinks": Array [],
               "reference": null,
@@ -224,10 +224,10 @@ Object {
             "node": Object {
               "id": "foo2",
             },
-            "score": 0.72331494,
+            "score": 0.5303296,
           },
           Object {
-            "cursor": "WzAuNjY2MjExMSwibWVkaWFBcnRpY2xlIl0=",
+            "cursor": "WzAuNDg3ODUxNywibWVkaWFBcnRpY2xlIl0=",
             "highlight": Object {
               "hyperlinks": Array [],
               "reference": null,
@@ -236,7 +236,7 @@ Object {
             "node": Object {
               "id": "mediaArticle",
             },
-            "score": 0.6662111,
+            "score": 0.4878517,
           },
         ],
       },
@@ -252,28 +252,28 @@ Object {
       "relatedArticles": Object {
         "edges": Array [
           Object {
-            "cursor": "WzAuNjY2MjExMSwibWVkaWFBcnRpY2xlIl0=",
+            "cursor": "WzAuNDg3ODUxNywibWVkaWFBcnRpY2xlIl0=",
             "node": Object {
               "id": "mediaArticle",
               "text": "Lorum ipsum",
             },
-            "score": 0.6662111,
+            "score": 0.4878517,
           },
           Object {
-            "cursor": "WzAuNzIzMzE0OTQsImZvbzIiXQ==",
+            "cursor": "WzAuNTMwMzI5NiwiZm9vMiJd",
             "node": Object {
               "id": "foo2",
               "text": "Lorum ipsum Lorum ipsum",
             },
-            "score": 0.72331494,
+            "score": 0.5303296,
           },
           Object {
-            "cursor": "WzEuMTg0OTAyMywiZm9vMyJd",
+            "cursor": "WzAuOTg2NDk1MywiZm9vMyJd",
             "node": Object {
               "id": "foo3",
               "text": "Lorum ipsum Lorum ipsum Lorum ipsum",
             },
-            "score": 1.1849023,
+            "score": 0.9864953,
           },
         ],
       },

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -429,6 +429,7 @@ export function filterByStatuses(entriesWithStatus, statuses) {
   return entriesWithStatus.filter(({ status }) => statuses.includes(status));
 }
 
+export const DEFAULT_ARTICLE_STATUSES = ['NORMAL'];
 export const DEFAULT_ARTICLE_REPLY_STATUSES = ['NORMAL'];
 export const DEFAULT_ARTICLE_CATEGORY_STATUSES = ['NORMAL'];
 export const DEFAULT_REPLY_REQUEST_STATUSES = ['NORMAL'];


### PR DESCRIPTION
- Sync DB field
- Creation API `CreateArticle`, `CreateMediaArticle` writes to `status` field
- `ListArticles` adds `statuses` filter; do not list out `BLOCKED` articles by default
- `relatedArticles` in `Article` do not list out `BLOCKED` articles by default
    - exception: for blocked articles, its `relatedArticles` will also include blocked articles