### PR TITLE
Block new articles from blocked users

### DIFF
--- a/src/graphql/mutations/__tests__/CreateArticle.js
+++ b/src/graphql/mutations/__tests__/CreateArticle.js
@@ -169,7 +169,7 @@ describe('creation', () => {
 
     const userId = 'iAmBlocked';
     const appId = 'foo';
-    const { data, errors } = await gql`
+    const { data } = await gql`
       mutation($text: String!, $reference: ArticleReferenceInput!) {
         CreateArticle(text: $text, reference: $reference, reason: "") {
           id
@@ -177,8 +177,7 @@ describe('creation', () => {
       }
     `(
       {
-        text:
-          'This is a scam (and I am actually scam too) http://evil.blog/article/1',
+        text: 'This is a scam (and I am actually scam too)',
         reference: { type: 'LINE' },
       },
       {
@@ -190,8 +189,6 @@ describe('creation', () => {
       }
     );
     MockDate.reset();
-
-    expect(errors).toBeUndefined();
 
     const {
       body: { _source: article },

--- a/src/graphql/mutations/__tests__/CreateArticle.js
+++ b/src/graphql/mutations/__tests__/CreateArticle.js
@@ -163,6 +163,75 @@ describe('creation', () => {
       id: replyRequestId,
     });
   });
+
+  it('sets status to blocked when author is blocked', async () => {
+    MockDate.set(1485593157011);
+
+    const userId = 'iAmBlocked';
+    const appId = 'foo';
+    const { data, errors } = await gql`
+      mutation($text: String!, $reference: ArticleReferenceInput!) {
+        CreateArticle(text: $text, reference: $reference, reason: "") {
+          id
+        }
+      }
+    `(
+      {
+        text:
+          'This is a scam (and I am actually scam too) http://evil.blog/article/1',
+        reference: { type: 'LINE' },
+      },
+      {
+        user: {
+          id: userId,
+          appId,
+          blockedReason: 'Announcement url',
+        },
+      }
+    );
+    MockDate.reset();
+
+    expect(errors).toBeUndefined();
+
+    const {
+      body: { _source: article },
+    } = await client.get({
+      index: 'articles',
+      type: 'doc',
+      id: data.CreateArticle.id,
+    });
+
+    expect(article).toHaveProperty('status', 'BLOCKED');
+
+    const replyRequestId = getReplyRequestId({
+      articleId: data.CreateArticle.id,
+      userId,
+      appId,
+    });
+
+    const {
+      body: { _source: replyRequest },
+    } = await client.get({
+      index: 'replyrequests',
+      type: 'doc',
+      id: replyRequestId,
+    });
+
+    expect(replyRequest).toHaveProperty('status', 'BLOCKED');
+
+    // Cleanup
+    await client.delete({
+      index: 'articles',
+      type: 'doc',
+      id: data.CreateArticle.id,
+    });
+
+    await client.delete({
+      index: 'replyrequests',
+      type: 'doc',
+      id: replyRequestId,
+    });
+  });
 });
 
 const testId = async (userId, appId) => {

--- a/src/graphql/mutations/__tests__/CreateMediaArticle.js
+++ b/src/graphql/mutations/__tests__/CreateMediaArticle.js
@@ -318,7 +318,7 @@ describe('creation', () => {
         articleType: 'IMAGE',
         reference: { type: 'LINE' },
       },
-      { user: { id: userId, appId } }
+      { user: { id: userId, appId, blockedReason: 'announcement-url' } }
     );
     MockDate.reset();
 

--- a/src/graphql/mutations/__tests__/CreateMediaArticle.js
+++ b/src/graphql/mutations/__tests__/CreateMediaArticle.js
@@ -297,7 +297,7 @@ describe('creation', () => {
       type: 'image',
     }));
 
-    const { data, errors } = await gql`
+    const { data } = await gql`
       mutation(
         $mediaUrl: String!
         $articleType: ArticleTypeEnum!


### PR DESCRIPTION
In https://github.com/cofacts/rumors-api/pull/293 we introduced `status` field for `articles`, but we set all article's status to `NORMAL`.

In this PR, we apply changes similar to [other APIs](https://github.com/cofacts/rumors-api/commit/9e7c1497a594d4b3752c090a8c9cae04cf749706) to determine the default status of an article by if the user is blocked.
 