### PR TITLE
Implement ListAIResponses

### DIFF
--- a/src/graphql/queries/ListAIResponses.js
+++ b/src/graphql/queries/ListAIResponses.js
@@ -1,0 +1,89 @@
+import { GraphQLNonNull, GraphQLID, GraphQLList } from 'graphql';
+import {
+  createFilterType,
+  createSortType,
+  getSortArgs,
+  pagingArgs,
+  createCommonListFilter,
+  attachCommonListFilter,
+  getRangeFieldParamFromArithmeticExpression,
+  timeRangeInput,
+} from 'graphql/util';
+
+import { AIResponseConnection } from 'graphql/models/AIResponse';
+import AIResponseTypeEnum from 'graphql/models/AIResponseTypeEnum';
+import AIResponseStatusEnum from 'graphql/models/AIResponseStatusEnum';
+
+export default {
+  args: {
+    filter: {
+      type: createFilterType('ListAIResponsesFilter', {
+        ...createCommonListFilter('AI responses'),
+        types: {
+          description:
+            'If specified, only return AI repsonses with the specified types.',
+          type: new GraphQLList(new GraphQLNonNull(AIResponseTypeEnum)),
+        },
+        docIds: {
+          description:
+            'If specified, only return AI repsonses under the specified doc IDs.',
+          type: new GraphQLList(new GraphQLNonNull(GraphQLID)),
+        },
+        statuses: {
+          description:
+            'If specified, only return AI repsonses under the specified statuses.',
+          type: new GraphQLList(new GraphQLNonNull(AIResponseStatusEnum)),
+        },
+        updatedAt: {
+          type: timeRangeInput,
+          description:
+            'List only the AI responses updated within the specific time range.',
+        },
+      }),
+    },
+    orderBy: {
+      type: createSortType('ListAIResponsesOrderBy', [
+        'createdAt',
+        'updatedAt',
+      ]),
+    },
+    ...pagingArgs,
+  },
+  type: new GraphQLNonNull(AIResponseConnection),
+  async resolve(
+    rootValue,
+    { filter = {}, orderBy = [], ...otherParams },
+    { userId, appId }
+  ) {
+    const body = {
+      sort: getSortArgs(orderBy),
+      query: {
+        bool: {
+          filter: [],
+        },
+      },
+    };
+
+    attachCommonListFilter(body.query.bool.filter, filter, userId, appId);
+
+    if (filter.updatedAt) {
+      body.query.bool.filter.push({
+        range: {
+          date: getRangeFieldParamFromArithmeticExpression(filter.updatedAt),
+        },
+      });
+    }
+
+    ['types', 'docIds', 'statuses'].forEach(field => {
+      if (!filter[field]) return;
+      body.query.bool.filter.push({ terms: { [`${field}`]: filter[field] } });
+    });
+
+    return {
+      index: 'airesponses',
+      type: 'doc',
+      body,
+      ...otherParams,
+    };
+  },
+};

--- a/src/graphql/queries/ListAIResponses.js
+++ b/src/graphql/queries/ListAIResponses.js
@@ -74,10 +74,14 @@ export default {
       });
     }
 
-    ['types', 'docIds', 'statuses'].forEach(field => {
-      if (!filter[field]) return;
-      body.query.bool.filter.push({ terms: { [`${field}`]: filter[field] } });
-    });
+    [['types', 'type'], ['docIds', 'docId'], ['statuses', 'status']].forEach(
+      ([filterField, docField]) => {
+        if (!filter[filterField]) return;
+        body.query.bool.filter.push({
+          terms: { [`${docField}`]: filter[filterField] },
+        });
+      }
+    );
 
     return {
       index: 'airesponses',

--- a/src/graphql/queries/ListAIResponses.js
+++ b/src/graphql/queries/ListAIResponses.js
@@ -69,7 +69,9 @@ export default {
     if (filter.updatedAt) {
       body.query.bool.filter.push({
         range: {
-          updatedAt: getRangeFieldParamFromArithmeticExpression(filter.updatedAt),
+          updatedAt: getRangeFieldParamFromArithmeticExpression(
+            filter.updatedAt
+          ),
         },
       });
     }

--- a/src/graphql/queries/ListAIResponses.js
+++ b/src/graphql/queries/ListAIResponses.js
@@ -69,7 +69,7 @@ export default {
     if (filter.updatedAt) {
       body.query.bool.filter.push({
         range: {
-          date: getRangeFieldParamFromArithmeticExpression(filter.updatedAt),
+          updatedAt: getRangeFieldParamFromArithmeticExpression(filter.updatedAt),
         },
       });
     }

--- a/src/graphql/queries/__fixtures__/ListAIResponses.js
+++ b/src/graphql/queries/__fixtures__/ListAIResponses.js
@@ -4,12 +4,14 @@ export default {
     type: 'AI_REPLY',
     status: 'SUCCESS',
     createdAt: '2020-01-01T00:00:00.000Z',
+    updatedAt: '2020-01-01T00:00:10.000Z',
   },
   '/airesponses/doc/ai-reply-latest': {
     docId: 'ai-replied-article',
     type: 'AI_REPLY',
     status: 'SUCCESS',
     createdAt: '2020-01-02T00:00:00.000Z',
+    updatedAt: '2020-01-02T00:00:15.000Z',
   },
   '/airesponses/doc/expired-loading': {
     docId: 'ai-replied-article',

--- a/src/graphql/queries/__fixtures__/ListAIResponses.js
+++ b/src/graphql/queries/__fixtures__/ListAIResponses.js
@@ -1,0 +1,26 @@
+export default {
+  '/airesponses/doc/ai-reply-old': {
+    docId: 'ai-replied-article',
+    type: 'AI_REPLY',
+    status: 'SUCCESS',
+    createdAt: '2020-01-01T00:00:00.000Z',
+  },
+  '/airesponses/doc/ai-reply-latest': {
+    docId: 'ai-replied-article',
+    type: 'AI_REPLY',
+    status: 'SUCCESS',
+    createdAt: '2020-01-02T00:00:00.000Z',
+  },
+  '/airesponses/doc/expired-loading': {
+    docId: 'ai-replied-article',
+    type: 'AI_REPLY',
+    status: 'ERROR',
+    createdAt: '2020-01-04T00:00:00.000Z',
+  },
+  '/airesponses/doc/loading': {
+    docId: 'some-article',
+    type: 'AI_REPLY',
+    status: 'LOADING',
+    createdAt: '2020-01-01T00:00:00.000Z',
+  },
+};

--- a/src/graphql/queries/__tests__/ListAIReponses.js
+++ b/src/graphql/queries/__tests__/ListAIReponses.js
@@ -1,0 +1,84 @@
+import gql from 'util/GraphQL';
+import { loadFixtures, unloadFixtures } from 'util/fixtures';
+import fixtures from '../__fixtures__/ListAIResponses';
+// import { getCursor } from 'graphql/util';
+
+describe('ListAIResponses', () => {
+  beforeAll(() => loadFixtures(fixtures));
+  afterAll(() => unloadFixtures(fixtures));
+
+  it('lists all AI responses', async () => {
+    expect(
+      await gql`
+        {
+          ListAIResponses {
+            totalCount
+            edges {
+              node {
+                id
+              }
+              cursor
+            }
+            pageInfo {
+              firstCursor
+              lastCursor
+            }
+          }
+        }
+      `()
+    ).toMatchSnapshot();
+  });
+
+  it('sorts', async () => {
+    expect(
+      await gql`
+        {
+          ListAIResponses(orderBy: [{ createdAt: DESC }]) {
+            edges {
+              node {
+                id
+                createdAt
+              }
+            }
+          }
+        }
+      `()
+    ).toMatchSnapshot('by createdAt DESC');
+  });
+
+  it('filters by common filters', async () => {
+    expect(
+      await gql`
+        {
+          ListAIResponses(
+            filter: { createdAt: { LTE: "2020-01-03T00:00:00.000Z" } }
+          ) {
+            edges {
+              node {
+                id
+                createdAt
+              }
+            }
+          }
+        }
+      `()
+    ).toMatchSnapshot('createdAt <= 2020/01/03');
+  });
+
+  it('filters by AI response specific filters', async () => {
+    expect(
+      await gql`
+        {
+          ListAIResponses(filter: { statuses: [ERROR, SUCCESS] }) {
+            edges {
+              node {
+                id
+                status
+              }
+            }
+          }
+        }
+      `()
+    ).toMatchSnapshot('only error and success');
+  });
+});

--- a/src/graphql/queries/__tests__/ListAIResponses.js
+++ b/src/graphql/queries/__tests__/ListAIResponses.js
@@ -80,5 +80,21 @@ describe('ListAIResponses', () => {
         }
       `()
     ).toMatchSnapshot('only error and success');
+    expect(
+      await gql`
+        {
+          ListAIResponses(
+            filter: { updatedAt: { LTE: "2020-01-02T00:00:10.000Z" } }
+          ) {
+            edges {
+              node {
+                id
+                updatedAt
+              }
+            }
+          }
+        }
+      `()
+    ).toMatchSnapshot('updatedAt <= 2020/1/2 00:00:10');
   });
 });

--- a/src/graphql/queries/__tests__/ListReplies.js
+++ b/src/graphql/queries/__tests__/ListReplies.js
@@ -169,6 +169,30 @@ describe('ListReplies', () => {
         }
       )
     ).toMatchSnapshot('userId = foo');
+
+    expect(
+      await gql`
+        {
+          ListReplies(filter: { userIds: ["foo"] }) {
+            edges {
+              node {
+                id
+                user {
+                  id
+                }
+              }
+            }
+            totalCount
+          }
+        }
+      `(
+        {},
+        {
+          userId: 'foo',
+          appId: 'test',
+        }
+      )
+    ).toMatchSnapshot('userIds = [foo]');
   });
 
   it('filters by moreLikeThis and given text, find replies containing hyperlinks with the said text', async () => {

--- a/src/graphql/queries/__tests__/__snapshots__/ListAIReponses.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListAIReponses.js.snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ListAIResponses filters by AI response specific filters: only error and success 1`] = `
+Object {
+  "data": Object {
+    "ListAIResponses": Object {
+      "edges": Array [],
+    },
+  },
+}
+`;
+
+exports[`ListAIResponses filters by common filters: createdAt <= 2020/01/03 1`] = `
+Object {
+  "data": Object {
+    "ListAIResponses": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "createdAt": "2020-01-01T00:00:00.000Z",
+            "id": "loading",
+          },
+        },
+        Object {
+          "node": Object {
+            "createdAt": "2020-01-01T00:00:00.000Z",
+            "id": "ai-reply-old",
+          },
+        },
+        Object {
+          "node": Object {
+            "createdAt": "2020-01-02T00:00:00.000Z",
+            "id": "ai-reply-latest",
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`ListAIResponses lists all AI responses 1`] = `
+Object {
+  "data": Object {
+    "ListAIResponses": Object {
+      "edges": Array [
+        Object {
+          "cursor": "WyJsb2FkaW5nIl0=",
+          "node": Object {
+            "id": "loading",
+          },
+        },
+        Object {
+          "cursor": "WyJleHBpcmVkLWxvYWRpbmciXQ==",
+          "node": Object {
+            "id": "expired-loading",
+          },
+        },
+        Object {
+          "cursor": "WyJhaS1yZXBseS1vbGQiXQ==",
+          "node": Object {
+            "id": "ai-reply-old",
+          },
+        },
+        Object {
+          "cursor": "WyJhaS1yZXBseS1sYXRlc3QiXQ==",
+          "node": Object {
+            "id": "ai-reply-latest",
+          },
+        },
+      ],
+      "pageInfo": Object {
+        "firstCursor": "WyJsb2FkaW5nIl0=",
+        "lastCursor": "WyJhaS1yZXBseS1sYXRlc3QiXQ==",
+      },
+      "totalCount": 4,
+    },
+  },
+}
+`;
+
+exports[`ListAIResponses sorts: by createdAt DESC 1`] = `
+Object {
+  "data": Object {
+    "ListAIResponses": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "createdAt": "2020-01-04T00:00:00.000Z",
+            "id": "expired-loading",
+          },
+        },
+        Object {
+          "node": Object {
+            "createdAt": "2020-01-02T00:00:00.000Z",
+            "id": "ai-reply-latest",
+          },
+        },
+        Object {
+          "node": Object {
+            "createdAt": "2020-01-01T00:00:00.000Z",
+            "id": "loading",
+          },
+        },
+        Object {
+          "node": Object {
+            "createdAt": "2020-01-01T00:00:00.000Z",
+            "id": "ai-reply-old",
+          },
+        },
+      ],
+    },
+  },
+}
+`;

--- a/src/graphql/queries/__tests__/__snapshots__/ListAIResponses.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListAIResponses.js.snap
@@ -4,7 +4,43 @@ exports[`ListAIResponses filters by AI response specific filters: only error and
 Object {
   "data": Object {
     "ListAIResponses": Object {
-      "edges": Array [],
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "expired-loading",
+            "status": "ERROR",
+          },
+        },
+        Object {
+          "node": Object {
+            "id": "ai-reply-old",
+            "status": "SUCCESS",
+          },
+        },
+        Object {
+          "node": Object {
+            "id": "ai-reply-latest",
+            "status": "SUCCESS",
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`ListAIResponses filters by AI response specific filters: updatedAt <= 2020/1/2 00:00:10 1`] = `
+Object {
+  "data": Object {
+    "ListAIResponses": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "ai-reply-old",
+            "updatedAt": "2020-01-01T00:00:10.000Z",
+          },
+        },
+      ],
     },
   },
 }

--- a/src/graphql/queries/__tests__/__snapshots__/ListReplies.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListReplies.js.snap
@@ -328,6 +328,26 @@ Object {
 }
 `;
 
+exports[`ListReplies filters: userIds = [foo] 1`] = `
+Object {
+  "data": Object {
+    "ListReplies": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "id": "userFoo",
+            "user": Object {
+              "id": "foo",
+            },
+          },
+        },
+      ],
+      "totalCount": 1,
+    },
+  },
+}
+`;
+
 exports[`ListReplies handles selfOnly filter properly if not logged in 1`] = `
 Object {
   "data": Object {

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -12,6 +12,7 @@ import ListArticleReplyFeedbacks from './queries/ListArticleReplyFeedbacks';
 import ListReplyRequests from './queries/ListReplyRequests';
 import ListBlockedUsers from './queries/ListBlockedUsers';
 import ListAnalytics from './queries/ListAnalytics';
+import ListAIResponses from './queries/ListAIResponses';
 import ValidateSlug from './queries/ValidateSlug';
 
 // Set individual objects
@@ -45,6 +46,7 @@ export default new GraphQLSchema({
       ListReplyRequests,
       ListBlockedUsers,
       ListAnalytics,
+      ListAIResponses,
       ValidateSlug,
     },
   }),

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -449,6 +449,10 @@ export function createCommonListFilter(pluralEntityName) {
       type: GraphQLString,
       description: `Show only ${pluralEntityName} created by the specific user.`,
     },
+    userIds: {
+      type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
+      description: `Show only ${pluralEntityName} created by the specified users.`,
+    },
     createdAt: {
       type: timeRangeInput,
       description: `List only the ${pluralEntityName} that were created between the specific time range.`,
@@ -484,6 +488,10 @@ export function attachCommonListFilter(
     if (!filter[field]) return;
     filterQueries.push({ term: { [`${fieldPrefix}${field}`]: filter[field] } });
   });
+
+  if (filter.userIds) {
+    filterQueries.push({ terms: { [`${fieldPrefix}userId`]: filter.userIds } });
+  }
 
   if (filter.createdAt) {
     filterQueries.push({


### PR DESCRIPTION
Implement `ListAIResponses` as planned in Phase 0: https://g0v.hackmd.io/@cofacts/rknFrmdk3#Phase-0-preparation

- Can filter by `createdAt`, `updatedAt`, `status`, `type`, etc.
- This PR also adds `userIds` to common filter, and add unit test