### PR TITLE
feat: better organized request logs

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -104,5 +104,5 @@ GCS_MEDIA_FOLDER=media/
 #
 OPENAI_API_KEY=
 
-# When LOG_REQUESTS exists, it also shows incoming GraphQL request, variables, and resolved user info
+# When LOG_REQUESTS exists, it also shows incoming GraphQL operation, variables, and resolved user info
 LOG_REQUESTS=

--- a/src/index.js
+++ b/src/index.js
@@ -88,6 +88,7 @@ const LOG_STR_LENGTH = 200;
 /**
  * For JSON.stringify in GraphQL logger
  */
+/* istanbul ignore next */
 function truncatingLogReplacer(key, value) {
   if (typeof value !== 'string' || value.length < LOG_STR_LENGTH) return value;
 


### PR DESCRIPTION
This is part of the operation layer enhancement; see https://g0v.hackmd.io/luIa-z9HToC2zlFpD9yK3w#Op-%E5%88%86%E8%BA%AB%E5%B8%B3%E8%99%9F%E8%99%95%E7%90%86 .

Reorganize the logs in logging mechanism
- records HTTP header for GraphQL requests
    - Also logs operation name, query, variables
    - Enables tracking operations of a certain IP address
- Compact GraphQL logging
    - Long strings are truncated with "..."

## Screenshot
First log comes from GraphQL plugin. The next log comes from pino logger.
![image](https://github.com/cofacts/rumors-api/assets/108608/d85e9c4e-2c60-44e2-b2f6-20e3c6925e0b)
