### PR TITLE
feat: record less bytes in GraphQL request

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,21 +145,20 @@ export const apolloServer = new ApolloServer({
             const [
               {
                 context: { userId, appUserId, appId },
-                request: { operationName, query, variables, http },
+                request: { operationName, query, http },
               },
             ] = args;
 
             console.log(
               JSON.stringify(
                 {
-                  msg: 'GraphQL request did start',
+                  msg: 'Apollo#requestDidStart',
                   operationName,
                   // Remove extra spaces and line breaks to further compress the query
                   query: (query ?? '')
                     .split('\n')
                     .map(line => line.trim())
                     .join(' '),
-                  variables,
                   userId,
                   appUserId,
                   appId,

--- a/src/index.js
+++ b/src/index.js
@@ -158,6 +158,7 @@ export const apolloServer = new ApolloServer({
                   query: (query ?? '')
                     .split('\n')
                     .map(line => line.trim())
+                    .filter(Boolean)
                     .join(' '),
                   userId,
                   appUserId,


### PR DESCRIPTION
- Only record IP related header for easier user tracking
  - headers makes ~70% of the log length
  - other headers are already captured by pino
- remove spaces GraphQL query and reduce string length cap
- Removes variables from GraphQL to exclude sensitive data.

![image](https://github.com/cofacts/rumors-api/assets/108608/5d2cad4e-48b6-45d0-afef-4b0e2e388b41)
