### PR TITLE
[3] Expose media similarity in ListArticles

### DIFF
--- a/src/__tests__/__snapshots__/auth.js.snap
+++ b/src/__tests__/__snapshots__/auth.js.snap
@@ -3,6 +3,7 @@
 exports[`verifyProfile authenticates user via profile ID 1`] = `
 Object {
   "_cursor": undefined,
+  "_fields": undefined,
   "_score": 0.2876821,
   "email": "secret@secret.com",
   "facebookId": "secret-fb-id",
@@ -16,6 +17,7 @@ Object {
 exports[`verifyProfile authenticates user via same email of existing user; also updates profile ID 1`] = `
 Object {
   "_cursor": undefined,
+  "_fields": undefined,
   "_score": undefined,
   "email": "secret@secret.com",
   "facebookId": "secret-fb-id",
@@ -31,6 +33,7 @@ Object {
 exports[`verifyProfile creates new user if user does not exist 1`] = `
 Object {
   "_cursor": undefined,
+  "_fields": undefined,
   "_score": undefined,
   "avatarUrl": "url-to-photo",
   "createdAt": "1989-06-04T00:00:00.000Z",

--- a/src/graphql/dataLoaders/__tests__/__snapshots__/userLoaderFactory.js.snap
+++ b/src/graphql/dataLoaders/__tests__/__snapshots__/userLoaderFactory.js.snap
@@ -3,6 +3,7 @@
 exports[`userLoaderFactory should return correct user with given slug 1`] = `
 Object {
   "_cursor": undefined,
+  "_fields": undefined,
   "_score": 0.6931472,
   "email": "secret@secret.com",
   "highlight": undefined,
@@ -16,6 +17,7 @@ Object {
 exports[`userLoaderFactory should return correct user with given slug 2`] = `
 Object {
   "_cursor": undefined,
+  "_fields": undefined,
   "_score": 0.6931472,
   "email": "hi@me.com",
   "highlight": undefined,

--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -553,8 +553,10 @@ export const ArticleConnection = createConnectionType(
   {
     extraEdgeFields: {
       mediaSimilarity: {
-        type: GraphQLFloat,
-        resolve: ({ node: { mediaSimilarity } }) => mediaSimilarity,
+        type: new GraphQLNonNull(GraphQLFloat),
+        description: `The search hit's similarity with provided mediaUrl.
+          Ranges from 0 to 1. 0 if mediaUrl is not provided, or the hit is not matched by mediaUrl.`,
+        resolve: ({ node }) => node._fields?.mediaSimilarity?.[0] ?? 0,
       },
     },
   }

--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -7,6 +7,7 @@ import {
   GraphQLInt,
   GraphQLBoolean,
   GraphQLEnumType,
+  GraphQLFloat,
 } from 'graphql';
 
 import {
@@ -20,6 +21,7 @@ import {
   createCommonListFilter,
   filterByStatuses,
   timeRangeInput,
+  defaultResolveEdges,
   DEFAULT_ARTICLE_REPLY_STATUSES,
   DEFAULT_ARTICLE_CATEGORY_STATUSES,
   DEFAULT_REPLY_REQUEST_STATUSES,
@@ -548,7 +550,15 @@ const Article = new GraphQLObjectType({
 
 export const ArticleConnection = createConnectionType(
   'ArticleConnection',
-  Article
+  Article,
+  {
+    extraEdgeFields: {
+      mediaSimilarity: {
+        type: GraphQLFloat,
+        resolve: ({ node: { mediaSimilarity } }) => mediaSimilarity,
+      },
+    },
+  }
 );
 
 export default Article;

--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -21,7 +21,6 @@ import {
   createCommonListFilter,
   filterByStatuses,
   timeRangeInput,
-  defaultResolveEdges,
   DEFAULT_ARTICLE_REPLY_STATUSES,
   DEFAULT_ARTICLE_CATEGORY_STATUSES,
   DEFAULT_REPLY_REQUEST_STATUSES,

--- a/src/graphql/models/__tests__/__snapshots__/User.js.snap
+++ b/src/graphql/models/__tests__/__snapshots__/User.js.snap
@@ -3,6 +3,7 @@
 exports[`User model userFieldResolver returns the right backend user given appUserId 1`] = `
 Object {
   "_cursor": undefined,
+  "_fields": undefined,
   "_score": undefined,
   "appId": "TEST_BACKEND",
   "appUserId": "userTest1",
@@ -16,6 +17,7 @@ Object {
 exports[`User model userFieldResolver returns the right backend user given db userId 1`] = `
 Object {
   "_cursor": undefined,
+  "_fields": undefined,
   "_score": undefined,
   "appId": "TEST_BACKEND",
   "appUserId": "userTest1",
@@ -29,6 +31,7 @@ Object {
 exports[`User model userFieldResolver returns the right web user given userId 1`] = `
 Object {
   "_cursor": undefined,
+  "_fields": undefined,
   "_score": undefined,
   "appId": "WEBSITE",
   "highlight": undefined,

--- a/src/graphql/queries/__tests__/ListArticles.js
+++ b/src/graphql/queries/__tests__/ListArticles.js
@@ -1007,6 +1007,7 @@ describe('ListArticles', () => {
           "ListArticles": Object {
             "edges": Array [
               Object {
+                "mediaSimilarity": 1,
                 "node": Object {
                   "articleType": "IMAGE",
                   "attachmentHash": "ffff8000",
@@ -1016,6 +1017,7 @@ describe('ListArticles', () => {
                 "score": 100,
               },
               Object {
+                "mediaSimilarity": 0.5,
                 "node": Object {
                   "articleType": "IMAGE",
                   "attachmentHash": "ffff8001",
@@ -1025,6 +1027,7 @@ describe('ListArticles', () => {
                 "score": 60.03248,
               },
               Object {
+                "mediaSimilarity": 0,
                 "node": Object {
                   "articleType": "TEXT",
                   "attachmentHash": "",
@@ -1166,6 +1169,7 @@ describe('ListArticles', () => {
             <HIGHLIGHT>微之</HIGHLIGHT>，<HIGHLIGHT>微之</HIGHLIGHT>！<HIGHLIGHT>此夕此心</HIGHLIGHT>，<HIGHLIGHT>君知之乎</HIGHLIGHT>！
           ",
                 },
+                "mediaSimilarity": 0,
                 "node": Object {
                   "articleType": "TEXT",
                   "attachmentHash": "",

--- a/src/graphql/queries/__tests__/ListArticles.js
+++ b/src/graphql/queries/__tests__/ListArticles.js
@@ -990,6 +990,7 @@ describe('ListArticles', () => {
           ) {
             edges {
               score
+              mediaSimilarity
               node {
                 id
                 articleType
@@ -1139,6 +1140,7 @@ describe('ListArticles', () => {
           ) {
             edges {
               score
+              mediaSimilarity
               node {
                 id
                 articleType

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -230,7 +230,7 @@ async function defaultResolveTotalCount({
         query: searchContext.body.query,
       },
     })).body.count;
-  } catch (e) {
+  } catch (e) /* istanbul ignore next */ {
     console.error('[defaultResolveTotalCount]', JSON.stringify(e));
     throw e;
   }

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -222,16 +222,18 @@ async function defaultResolveTotalCount({
   after, // eslint-disable-line no-unused-vars
   ...searchContext
 }) {
-  return (await client.count({
-    ...searchContext,
-    body: {
-      ...searchContext.body,
-
-      // totalCount cannot support these
-      sort: undefined,
-      track_scores: undefined,
-    },
-  })).body.count;
+  try {
+    return (await client.count({
+      ...searchContext,
+      body: {
+        // count API only supports "query"
+        query: searchContext.body.query,
+      },
+    })).body.count;
+  } catch (e) {
+    console.error('[defaultResolveTotalCount]', JSON.stringify(e));
+    throw e;
+  }
 }
 
 export async function defaultResolveEdges(

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -368,6 +368,7 @@ export function createConnectionType(
     resolveLastCursor = defaultResolveLastCursor,
     resolveFirstCursor = defaultResolveFirstCursor,
     resolveHighlights = defaultResolveHighlights,
+    extraEdgeFields = {},
   } = {}
 ) {
   return new GraphQLObjectType({
@@ -395,6 +396,7 @@ export function createConnectionType(
                     type: Highlights,
                     resolve: resolveHighlights,
                   },
+                  ...extraEdgeFields,
                 },
               })
             )

--- a/src/scripts/__tests__/__snapshots__/cleanupUrls.js.snap
+++ b/src/scripts/__tests__/__snapshots__/cleanupUrls.js.snap
@@ -4,6 +4,7 @@ exports[`should clean up urls 1`] = `
 Array [
   Object {
     "_cursor": undefined,
+    "_fields": undefined,
     "_score": 1,
     "highlight": undefined,
     "id": "new-url",
@@ -11,6 +12,7 @@ Array [
   },
   Object {
     "_cursor": undefined,
+    "_fields": undefined,
     "_score": 1,
     "highlight": undefined,
     "id": "url-processed",
@@ -19,6 +21,7 @@ Array [
   },
   Object {
     "_cursor": undefined,
+    "_fields": undefined,
     "_score": 1,
     "highlight": undefined,
     "id": "url-foo",
@@ -27,6 +30,7 @@ Array [
   },
   Object {
     "_cursor": undefined,
+    "_fields": undefined,
     "_score": 1,
     "highlight": undefined,
     "id": "curl-foo",
@@ -35,6 +39,7 @@ Array [
   },
   Object {
     "_cursor": undefined,
+    "_fields": undefined,
     "_score": 1,
     "highlight": undefined,
     "id": "url-bar",
@@ -43,6 +48,7 @@ Array [
   },
   Object {
     "_cursor": undefined,
+    "_fields": undefined,
     "_score": 1,
     "highlight": undefined,
     "id": "curl-bar",

--- a/src/util/__tests__/__snapshots__/scrapUrls.js.snap
+++ b/src/util/__tests__/__snapshots__/scrapUrls.js.snap
@@ -6,6 +6,7 @@ Array [
     "_cursor": Array [
       1485907200000,
     ],
+    "_fields": undefined,
     "_score": null,
     "canonical": "http://example.com/article/1111",
     "fetchedAt": "2017-02-01T00:00:00.000Z",
@@ -22,6 +23,7 @@ Array [
     "_cursor": Array [
       1485907200000,
     ],
+    "_fields": undefined,
     "_score": null,
     "canonical": "http://example.com/article/1111",
     "fetchedAt": "2017-02-01T00:00:00.000Z",

--- a/src/util/__tests__/__snapshots__/user.js.snap
+++ b/src/util/__tests__/__snapshots__/user.js.snap
@@ -3,6 +3,7 @@
 exports[`user utils CreateOrUpdateUser creates backend user if not existed 1`] = `
 Object {
   "_cursor": undefined,
+  "_fields": undefined,
   "_score": undefined,
   "appId": "TEST_BACKEND",
   "appUserId": "testUser2",
@@ -34,6 +35,7 @@ Object {
 exports[`user utils CreateOrUpdateUser fills appId for website users 1`] = `
 Object {
   "_cursor": undefined,
+  "_fields": undefined,
   "_score": undefined,
   "appId": "WEBSITE",
   "highlight": undefined,
@@ -47,6 +49,7 @@ Object {
 exports[`user utils CreateOrUpdateUser logs error if collision occurs 1`] = `
 Object {
   "_cursor": undefined,
+  "_fields": undefined,
   "_score": undefined,
   "appId": "TEST_BACKEND",
   "appUserId": "testUser1",
@@ -78,6 +81,7 @@ Array [
 exports[`user utils CreateOrUpdateUser updates backend users' last active time if user already existed 1`] = `
 Object {
   "_cursor": undefined,
+  "_fields": undefined,
   "_score": undefined,
   "appId": "TEST_BACKEND",
   "appUserId": "testUser1",

--- a/src/util/client.js
+++ b/src/util/client.js
@@ -19,6 +19,8 @@ export function processMeta({
   inner_hits, // nested query search result highlighting.
 
   sort, // cursor when sorted
+
+  fields, // scripted fields (if any)
 }) {
   if (found || _score !== undefined) {
     return {
@@ -28,6 +30,7 @@ export function processMeta({
       _score,
       highlight,
       inner_hits,
+      _fields: fields,
     };
   }
   return null; // not found


### PR DESCRIPTION
During development, we found that actually it is possible for pure text to have score > 100
![image](https://github.com/cofacts/rumors-api/assets/108608/7bcc5c2b-ca91-4bc0-8f38-c51638e0bbf8).

In this PR, we expose MediaManager's similarity in the `edge` of `ListArticles`, so that clients like LINE bot don't need to rely on score to determine if there is a matching, similar image / video / etc file.

Refactors:
- [fix(graphql): default total count resolver should only use query in body](https://github.com/cofacts/rumors-api/commit/061daca53e00d12e519e1d2df6b73319527beb4f)
  - Ref: https://www.elastic.co/guide/en/elasticsearch/reference/current/search-count.html#search-count-request-body
  - Also adds console.error that prints the whole error message to aid debugging