### PR TITLE
Fix GetYdoc API

### DIFF
--- a/src/graphql/models/Ydoc.js
+++ b/src/graphql/models/Ydoc.js
@@ -9,6 +9,9 @@ const Ydoc = new GraphQLObjectType({
       type: GraphQLString,
       // https://www.elastic.co/guide/en/elasticsearch/reference/current/binary.html
       description: 'Binary that stores as base64 encoded string',
+      resolve: ({ ydoc }) => {
+        return ydoc;
+      },
     },
     versions: {
       type: new GraphQLList(YdocVersion),

--- a/src/graphql/queries/__fixtures__/GetYdoc.js
+++ b/src/graphql/queries/__fixtures__/GetYdoc.js
@@ -1,6 +1,6 @@
 export default {
   '/ydocs/doc/foo': {
-    data: 'mock data1',
+    ydoc: 'mock data1',
     versions: [
       {
         createdAt: '2023-09-07T08:14:14.005Z',
@@ -21,6 +21,6 @@ export default {
     ],
   },
   '/ydocs/doc/foo2': {
-    data: 'mock data2',
+    ydoc: 'mock data2',
   },
 };


### PR DESCRIPTION
The current implementation always gets `null` because it's reading the wrong field.

This PR fixes `GetYdoc` to read the correct field.