### PR TITLE
refactor: add non-null to common types' fields

### DIFF
--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -61,17 +61,19 @@ const Article = new GraphQLObjectType({
   fields: () => ({
     id: { type: new GraphQLNonNull(GraphQLID) },
     text: { type: GraphQLString },
-    createdAt: { type: GraphQLString },
+    createdAt: { type: new GraphQLNonNull(GraphQLString) },
     updatedAt: { type: GraphQLString },
     status: { type: new GraphQLNonNull(ReplyRequestStatusEnum) },
     references: { type: new GraphQLList(ArticleReference) },
     replyCount: {
-      type: GraphQLInt,
+      type: new GraphQLNonNull(GraphQLInt),
       description: 'Number of normal article replies',
-      resolve: ({ normalArticleReplyCount }) => normalArticleReplyCount,
+      resolve: ({ normalArticleReplyCount }) => normalArticleReplyCount ?? 0,
     },
     articleReplies: {
-      type: new GraphQLList(ArticleReply),
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(ArticleReply))
+      ),
       description:
         'Connections between this article and replies. Sorted by the logic described in https://github.com/cofacts/rumors-line-bot/issues/78.',
       args: {
@@ -203,7 +205,9 @@ const Article = new GraphQLObjectType({
     },
 
     articleCategories: {
-      type: new GraphQLList(ArticleCategory),
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(ArticleCategory))
+      ),
       args: {
         status: {
           type: ArticleCategoryStatusEnum,
@@ -239,9 +243,10 @@ const Article = new GraphQLObjectType({
     },
 
     categoryCount: {
-      type: GraphQLInt,
+      type: new GraphQLNonNull(GraphQLInt),
       description: 'Number of normal article categories',
-      resolve: ({ normalArticleCategoryCount }) => normalArticleCategoryCount,
+      resolve: ({ normalArticleCategoryCount }) =>
+        normalArticleCategoryCount ?? 0,
     },
 
     replyRequests: {
@@ -454,7 +459,7 @@ const Article = new GraphQLObjectType({
         };
       },
       // eslint-disable-next-line no-use-before-define
-      type: ArticleConnection,
+      type: new GraphQLNonNull(ArticleConnection),
     },
     hyperlinks: {
       type: new GraphQLList(Hyperlink),

--- a/src/graphql/models/ArticleReference.js
+++ b/src/graphql/models/ArticleReference.js
@@ -26,8 +26,8 @@ const ArticleReferenceTypeEnum = new GraphQLEnumType({
 export default new GraphQLObjectType({
   name: 'ArticleReference',
   fields: () => ({
-    createdAt: { type: GraphQLString },
-    type: { type: ArticleReferenceTypeEnum },
+    createdAt: { type: new GraphQLNonNull(GraphQLString) },
+    type: { type: new GraphQLNonNull(ArticleReferenceTypeEnum) },
     permalink: { type: GraphQLString },
   }),
 });

--- a/src/graphql/models/ArticleReply.js
+++ b/src/graphql/models/ArticleReply.js
@@ -25,7 +25,7 @@ export default new GraphQLObjectType({
   name: 'ArticleReply',
   description: 'The linkage between an Article and a Reply',
   fields: () => ({
-    replyId: { type: GraphQLString },
+    replyId: { type: new GraphQLNonNull(GraphQLString) },
 
     reply: {
       type: Reply,
@@ -38,7 +38,7 @@ export default new GraphQLObjectType({
       description: 'Cached reply type value stored in ArticleReply',
     },
 
-    articleId: { type: GraphQLString },
+    articleId: { type: new GraphQLNonNull(GraphQLString) },
 
     article: {
       type: Article,
@@ -56,23 +56,35 @@ export default new GraphQLObjectType({
     appId: { type: GraphQLNonNull(GraphQLString) },
 
     canUpdateStatus: {
-      type: GraphQLBoolean,
+      type: new GraphQLNonNull(GraphQLBoolean),
       resolve: ({ userId, appId }, args, { user }) => {
         return !!user && userId === user.id && appId === user.appId;
       },
     },
 
     feedbackCount: {
-      type: GraphQLInt,
+      type: new GraphQLNonNull(GraphQLInt),
       resolve: ({ positiveFeedbackCount = 0, negativeFeedbackCount = 0 }) =>
         positiveFeedbackCount + negativeFeedbackCount,
     },
 
-    positiveFeedbackCount: { type: GraphQLInt },
-    negativeFeedbackCount: { type: GraphQLInt },
+    positiveFeedbackCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+      resolve({ positiveFeedbackCount }) {
+        return positiveFeedbackCount ?? 0;
+      },
+    },
+    negativeFeedbackCount: {
+      type: new GraphQLNonNull(GraphQLInt),
+      resolve({ negativeFeedbackCount }) {
+        return negativeFeedbackCount ?? 0;
+      },
+    },
 
     feedbacks: {
-      type: new GraphQLList(ArticleReplyFeedback),
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(ArticleReplyFeedback))
+      ),
       args: {
         statuses: {
           type: new GraphQLList(
@@ -118,11 +130,11 @@ export default new GraphQLObjectType({
     },
 
     status: {
-      type: ArticleReplyStatusEnum,
+      type: new GraphQLNonNull(ArticleReplyStatusEnum),
       resolve: ({ status }) => (status === undefined ? 'NORMAL' : status),
     },
 
-    createdAt: { type: GraphQLString },
+    createdAt: { type: new GraphQLNonNull(GraphQLString) },
     updatedAt: { type: GraphQLString },
   }),
 });

--- a/src/graphql/models/Reply.js
+++ b/src/graphql/models/Reply.js
@@ -31,12 +31,14 @@ const Reply = new GraphQLObjectType({
       description: 'The user submitted this reply version',
       resolve: userFieldResolver,
     },
-    createdAt: { type: GraphQLString },
+    createdAt: { type: new GraphQLNonNull(GraphQLString) },
     text: { type: GraphQLString },
-    type: { type: ReplyTypeEnum },
+    type: { type: new GraphQLNonNull(ReplyTypeEnum) },
     reference: { type: GraphQLString },
     articleReplies: {
-      type: new GraphQLList(ArticleReply),
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(ArticleReply))
+      ),
       args: {
         status: {
           type: ArticleReplyStatusEnum,
@@ -143,7 +145,7 @@ const Reply = new GraphQLObjectType({
         };
       },
       // eslint-disable-next-line no-use-before-define
-      type: ReplyConnection,
+      type: new GraphQLNonNull(ReplyConnection),
     },
   }),
 });

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -435,7 +435,9 @@ export function createConnectionType(
  * @returns {Object[]}
  */
 export function filterByStatuses(entriesWithStatus, statuses) {
-  return entriesWithStatus.filter(({ status }) => statuses.includes(status));
+  return entriesWithStatus
+    .filter(Boolean) // Ensure no null inside
+    .filter(({ status }) => statuses.includes(status));
 }
 
 export const DEFAULT_ARTICLE_STATUSES = ['NORMAL'];


### PR DESCRIPTION
Make GraphQL return types more strict so that clients can have less null checks.

Range: `Article`, `Reply`, `ArticleReply`