### PR TITLE
Nullable createdat

### DIFF
--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -61,7 +61,10 @@ const Article = new GraphQLObjectType({
   fields: () => ({
     id: { type: new GraphQLNonNull(GraphQLID) },
     text: { type: GraphQLString },
-    createdAt: { type: new GraphQLNonNull(GraphQLString) },
+    createdAt: {
+      type: GraphQLString,
+      description: 'May be null for legacy articles',
+    },
     updatedAt: { type: GraphQLString },
     status: { type: new GraphQLNonNull(ReplyRequestStatusEnum) },
     references: { type: new GraphQLList(ArticleReference) },

--- a/src/graphql/models/ArticleReply.js
+++ b/src/graphql/models/ArticleReply.js
@@ -136,7 +136,7 @@ export default new GraphQLObjectType({
 
     createdAt: {
       type: GraphQLString,
-      description: 'May be null for legacy articles',
+      description: 'May be null for legacy article-replies',
     },
     updatedAt: { type: GraphQLString },
   }),

--- a/src/graphql/models/ArticleReply.js
+++ b/src/graphql/models/ArticleReply.js
@@ -134,7 +134,10 @@ export default new GraphQLObjectType({
       resolve: ({ status }) => (status === undefined ? 'NORMAL' : status),
     },
 
-    createdAt: { type: new GraphQLNonNull(GraphQLString) },
+    createdAt: {
+      type: GraphQLString,
+      description: 'May be null for legacy articles',
+    },
     updatedAt: { type: GraphQLString },
   }),
 });

--- a/src/graphql/models/Reply.js
+++ b/src/graphql/models/Reply.js
@@ -31,7 +31,10 @@ const Reply = new GraphQLObjectType({
       description: 'The user submitted this reply version',
       resolve: userFieldResolver,
     },
-    createdAt: { type: new GraphQLNonNull(GraphQLString) },
+    createdAt: {
+      type: GraphQLString,
+      description: 'May be null for legacy articles',
+    },
     text: { type: GraphQLString },
     type: { type: new GraphQLNonNull(ReplyTypeEnum) },
     reference: { type: GraphQLString },

--- a/src/graphql/models/Reply.js
+++ b/src/graphql/models/Reply.js
@@ -33,7 +33,7 @@ const Reply = new GraphQLObjectType({
     },
     createdAt: {
       type: GraphQLString,
-      description: 'May be null for legacy articles',
+      description: 'May be null for legacy replies',
     },
     text: { type: GraphQLString },
     type: { type: new GraphQLNonNull(ReplyTypeEnum) },


### PR DESCRIPTION
In 2023/10/25 pre-release test, we found that there are some articles not clickable on staging.
GraphQL error shows that there are some article, article-reply and replies [have no `createdeAt`](https://g0v.hackmd.io/ZOZrbHxEQV25eP7a4dxzYw#%E6%9C%AA%E7%AB%9F%E9%A0%85%E7%9B%AE). However, we set `createdAt` as non-null back in https://github.com/cofacts/rumors-api/pull/320

This PR removes the non-null restriction on `createdAt` for articles, replies and article-replies.
![圖片](https://github.com/cofacts/rumors-api/assets/108608/659616da-a9fe-45db-9bb6-22ffe9b66f95)
