### PR TITLE
fix(mutations): createOrUpdateCooccurrence should return id properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Builds production image for rumors-api.
 #
-FROM node:18-alpine AS builder
+FROM node:18-alpine3.18 AS builder
 WORKDIR /srv/www
 
 # make node_modules cached.
@@ -17,7 +17,7 @@ RUN node_modules/.bin/babel src -d build
 RUN npm prune --production
 
 #########################################
-FROM node:18-alpine
+FROM node:18-alpine3.18
 RUN apk update && apk add ffmpeg
 
 WORKDIR /srv/www

--- a/src/graphql/mutations/CreateOrUpdateCooccurrence.js
+++ b/src/graphql/mutations/CreateOrUpdateCooccurrence.js
@@ -56,7 +56,7 @@ export async function createOrUpdateCooccurrence({ articleIds, user }) {
   const isCreated = result === 'created';
 
   return {
-    cooccurrence: { ..._source },
+    cooccurrence: { id, ..._source },
     isCreated,
   };
 }

--- a/src/graphql/mutations/__tests__/CreateOrUpdateCooccurrence.js
+++ b/src/graphql/mutations/__tests__/CreateOrUpdateCooccurrence.js
@@ -17,6 +17,7 @@ describe('CreateOrUpdateCooccurrence', () => {
     const { data, errors } = await gql`
       mutation($articleIds: [String!]) {
         CreateOrUpdateCooccurrence(articleIds: $articleIds) {
+          id
           articles {
             text
           }

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateOrUpdateCooccurrence.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateOrUpdateCooccurrence.js.snap
@@ -15,6 +15,7 @@ Object {
       "text": "i am a2",
     },
   ],
+  "id": "test_test_a1_a2",
   "userId": "test",
 }
 `;


### PR DESCRIPTION
Currently `CreateOrUpdateCooccurrence` will error if `id` is queried in the mutation.

The root cause is that `id` is not given in the resolver. We did not capture this error because we do not include `id` in test script.

This PR fixes the root cause and make sure it's tested properly.

Blocks https://github.com/cofacts/rumors-line-bot/pull/379 .