### PR TITLE
Add article contributors

### DIFF
--- a/src/graphql/__tests__/util.js
+++ b/src/graphql/__tests__/util.js
@@ -120,6 +120,7 @@ if (process.env.GCS_BUCKET_NAME) {
         createdAt,
         // eslint-disable-next-line no-unused-vars
         updatedAt,
+        text,
         ...aiResponse
       } = await createTranscript(
         {
@@ -130,50 +131,21 @@ if (process.env.GCS_BUCKET_NAME) {
         { id: 'user-id', appId: 'app-id' }
       );
 
+      // Expect some keywords are identified.
+      // The whole text are not always 100% identical, but these keywords should be always included.
+      expect(text).toMatch(/^排/);
+      expect(text).toMatch(/德國醫學博士艾倫斯特發現/);
+      expect(text).toMatch(/汗也具有調節體溫的重要作用/);
       expect(aiResponse).toMatchInlineSnapshot(`
-        Object {
-          "appId": "app-id",
-          "docId": "foo",
-          "status": "SUCCESS",
-          "text": "排
-        汗
-        汗和排尿的差別
-        想要健康長壽就要想辦法一天一次大量排汗
-        德國醫學博士艾倫斯特發現:所有運動選手中
-        唯獨馬拉松選手沒有罹患癌症病例。
-        艾倫斯特博士採集了每天跑步 30 公里以上的
-        馬拉松選手的汗水,分析其汗水的成份結果
-        發現汗水中含有 鎘 鉛銅鎳等之重金屬物質。
-        證明出汗是排泄體內疲勞物質及對人體有害的
-        重金屬毒素的重要途徑
-        雖然排泄體內不需要物質的基本功能,有排便
-        排尿與出汗。而尿也會排出重金屬,但是排出
-        功能卻遠不及汗。
-        汗與尿中的重金屬元素量
-        鉛(微克)鎘(微克)鈷(微克)
-        6.5
-        1.2
-        0.65
-        0.6
-        汗 84
-        尿 4.9
-        100 克 中〉
-        鎳(微克)銅(毫克)
-        32
-        0.11
-        3.1
-        0.01
-        汗也具有調節體溫的重要作用。 全身健康的
-        出汗,就能夠強化現代最欠缺的體溫調節功能
-        與自律神經。
-        藉著汗,氣化熱消耗熱量,能夠提升代謝力,
-        不但減少體脂肪,還有助於消除肥胖。
-        可以先從關掉冷氣做起
-        ",
-          "type": "TRANSCRIPT",
-          "userId": "user-id",
-        }
-      `);
+      Object {
+        "appId": "app-id",
+        "docId": "foo",
+        "status": "SUCCESS",
+        "type": "TRANSCRIPT",
+        "userId": "user-id",
+      }
+    `);
+
       // Cleanup
       await client.delete({
         index: 'airesponses',

--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -595,12 +595,12 @@ const Article = new GraphQLObjectType({
         if (!contributors || contributors.length === 0) {
           return null;
         }
-        const maxUpdatedAt = contributors.reduce(
-          (max, contributor) =>
-            contributor.updatedAt > max ? contributor.updatedAt : max,
-          contributors[0].updatedAt
+        const maxUpdatedAt = new Date(
+          Math.max(
+            ...contributors.map(contributor => new Date(contributor.updatedAt))
+          )
         );
-        return maxUpdatedAt;
+        return maxUpdatedAt.toISOString();
       },
     },
   }),

--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -585,6 +585,21 @@ const Article = new GraphQLObjectType({
       type: new GraphQLList(Contributor),
       description: 'Transcript contributors of the article',
     },
+    transcribedAt: {
+      type: GraphQLString,
+      description: 'Time when the article was last transcribed',
+      resolve: async ({ contributors }) => {
+        if (!contributors || contributors.length === 0) {
+          return null;
+        }
+        const maxUpdatedAt = contributors.reduce(
+          (max, contributor) =>
+            contributor.updatedAt > max ? contributor.updatedAt : max,
+          contributors[0].updatedAt
+        );
+        return maxUpdatedAt;
+      },
+    },
   }),
 });
 

--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -44,6 +44,7 @@ import Hyperlink from './Hyperlink';
 import ReplyRequest from './ReplyRequest';
 import ArticleTypeEnum from './ArticleTypeEnum';
 import Cooccurrence from './Cooccurrence';
+import Contributor from './Contributor';
 
 const ATTACHMENT_URL_DURATION_DAY = 1;
 
@@ -579,6 +580,10 @@ const Article = new GraphQLObjectType({
             },
           },
         }),
+    },
+    contributors: {
+      type: new GraphQLList(Contributor),
+      description: 'Transcript contributors of the article',
     },
   }),
 });

--- a/src/graphql/models/Article.js
+++ b/src/graphql/models/Article.js
@@ -582,8 +582,11 @@ const Article = new GraphQLObjectType({
         }),
     },
     contributors: {
-      type: new GraphQLList(Contributor),
+      type: new GraphQLNonNull(
+        new GraphQLList(new GraphQLNonNull(Contributor))
+      ),
       description: 'Transcript contributors of the article',
+      resolve: ({ contributors }) => contributors ?? [],
     },
     transcribedAt: {
       type: GraphQLString,

--- a/src/graphql/models/Contributor.js
+++ b/src/graphql/models/Contributor.js
@@ -1,0 +1,10 @@
+import { GraphQLObjectType, GraphQLString, GraphQLNonNull } from 'graphql';
+
+export default new GraphQLObjectType({
+  name: 'Contributor',
+  fields: () => ({
+    userId: { type: GraphQLNonNull(GraphQLString) },
+    appId: { type: GraphQLNonNull(GraphQLString) },
+    updatedAt: { type: GraphQLString },
+  }),
+});

--- a/src/graphql/models/Contributor.js
+++ b/src/graphql/models/Contributor.js
@@ -1,8 +1,14 @@
 import { GraphQLObjectType, GraphQLString, GraphQLNonNull } from 'graphql';
+import User, { userFieldResolver } from './User';
 
 export default new GraphQLObjectType({
   name: 'Contributor',
   fields: () => ({
+    user: {
+      type: User,
+      description: 'The user who contributed to this article.',
+      resolve: userFieldResolver,
+    },
     userId: { type: GraphQLNonNull(GraphQLString) },
     appId: { type: GraphQLNonNull(GraphQLString) },
     updatedAt: { type: GraphQLString },

--- a/src/graphql/mutations/CreateArticle.js
+++ b/src/graphql/mutations/CreateArticle.js
@@ -82,6 +82,7 @@ async function createNewArticle({ text, reference: originalReference, user }) {
         attachmentUrl: '',
         attachmentHash: '',
         status: getContentDefaultStatus(user),
+        contributors: [],
       },
     },
     refresh: 'true', // Make sure the data is indexed when we create ReplyRequest

--- a/src/graphql/mutations/CreateMediaArticle.js
+++ b/src/graphql/mutations/CreateMediaArticle.js
@@ -162,6 +162,7 @@ async function createNewMediaArticle({
       articleType,
       attachmentHash,
       status: getContentDefaultStatus(user),
+      contributors: [],
     },
   });
 

--- a/src/graphql/mutations/__tests__/CreateMediaArticle.js
+++ b/src/graphql/mutations/__tests__/CreateMediaArticle.js
@@ -84,6 +84,7 @@ describe('creation', () => {
         "articleReplies": Array [],
         "articleType": "IMAGE",
         "attachmentHash": "mock_image_hash",
+        "contributors": Array [],
         "createdAt": "2017-01-28T08:45:57.011Z",
         "hyperlinks": Array [],
         "lastRequestedAt": "2017-01-28T08:45:57.011Z",

--- a/src/graphql/mutations/__tests__/__snapshots__/CreateArticle.js.snap
+++ b/src/graphql/mutations/__tests__/__snapshots__/CreateArticle.js.snap
@@ -28,6 +28,7 @@ Object {
   "articleType": "TEXT",
   "attachmentHash": "",
   "attachmentUrl": "",
+  "contributors": Array [],
   "createdAt": "2017-01-28T08:45:57.011Z",
   "hyperlinks": Array [
     Object {

--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -565,14 +565,8 @@ export default {
         nested: {
           path: 'contributors',
           query: {
-            bool: {
-              must: [
-                {
-                  term: {
-                    'contributors.userId': filter.articleContributesFrom.userId,
-                  },
-                },
-              ],
+            term: {
+              'contributors.userId': filter.articleContributesFrom.userId,
             },
           },
         },

--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -16,6 +16,7 @@ import {
   intRangeInput,
   timeRangeInput,
   moreLikeThisInput,
+  userAndExistInput,
   getRangeFieldParamFromArithmeticExpression,
   createCommonListFilter,
   attachCommonListFilter,
@@ -136,34 +137,12 @@ export default {
         articleRepliesFrom: {
           description:
             'Show only articles with(out) article replies created by specified user',
-          type: new GraphQLInputObjectType({
-            name: 'UserAndExistInput',
-            fields: {
-              userId: {
-                type: new GraphQLNonNull(GraphQLString),
-              },
-              exists: {
-                type: GraphQLBoolean,
-                defaultValue: true,
-                description: `
-                  When true (or not specified), return only entries with the specified user's involvement.
-                  When false, return only entries that the specified user did not involve.
-                `,
-              },
-            },
-          }),
+          type: userAndExistInput,
         },
-        articleContributesFrom: {
+        transcribedBy: {
           description:
-            'Show only articles with article transcript contributed by specified user',
-          type: new GraphQLInputObjectType({
-            name: 'ArticleContributeInput',
-            fields: {
-              userId: {
-                type: new GraphQLNonNull(GraphQLString),
-              },
-            },
-          }),
+            'Show only articles with(out) article transcript contributed by specified user',
+          type: userAndExistInput,
         },
         hasArticleReplyWithMorePositiveFeedback: {
           type: GraphQLBoolean,
@@ -560,13 +539,16 @@ export default {
       });
     }
 
-    if (filter.articleContributesFrom) {
-      filterQueries.push({
+    if (filter.transcribedBy) {
+      (filter.transcribedBy.exists === false
+        ? mustNotQueries
+        : filterQueries
+      ).push({
         nested: {
           path: 'contributors',
           query: {
             term: {
-              'contributors.userId': filter.articleContributesFrom.userId,
+              'contributors.userId': filter.transcribedBy.userId,
             },
           },
         },

--- a/src/graphql/queries/ListArticles.js
+++ b/src/graphql/queries/ListArticles.js
@@ -153,6 +153,18 @@ export default {
             },
           }),
         },
+        articleContributesFrom: {
+          description:
+            'Show only articles with article transcript contributed by specified user',
+          type: new GraphQLInputObjectType({
+            name: 'ArticleContributeInput',
+            fields: {
+              userId: {
+                type: new GraphQLNonNull(GraphQLString),
+              },
+            },
+          }),
+        },
         hasArticleReplyWithMorePositiveFeedback: {
           type: GraphQLBoolean,
           description: `
@@ -539,6 +551,25 @@ export default {
                 {
                   term: {
                     'articleReplies.userId': filter.articleRepliesFrom.userId,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+    }
+
+    if (filter.articleContributesFrom) {
+      filterQueries.push({
+        nested: {
+          path: 'contributors',
+          query: {
+            bool: {
+              must: [
+                {
+                  term: {
+                    'contributors.userId': filter.articleContributesFrom.userId,
                   },
                 },
               ],

--- a/src/graphql/queries/__fixtures__/ListArticles.js
+++ b/src/graphql/queries/__fixtures__/ListArticles.js
@@ -46,6 +46,18 @@ export default {
         negativeFeedbackCount: 0,
       },
     ],
+    contributors: [
+      {
+        userId: 'user1',
+        appId: 'WEBSITE',
+        updatedAt: '2020-02-05T14:41:19.044Z',
+      },
+      {
+        userId: 'user2',
+        appId: 'WEBSITE',
+        updatedAt: '2020-02-05T14:41:19.044Z',
+      },
+    ],
     attachmentUrl: '',
     attachmentHash: '',
     articleType: 'TEXT',
@@ -103,6 +115,23 @@ export default {
         status: 'NORMAL',
         positiveFeedbackCount: 0,
         negativeFeedbackCount: 0,
+      },
+    ],
+    contributors: [
+      {
+        userId: 'user1',
+        appId: 'WEBSITE',
+        updatedAt: '2020-02-04T15:11:04.472Z',
+      },
+      {
+        userId: 'user3',
+        appId: 'WEBSITE',
+        updatedAt: '2020-02-08T14:41:19.044Z',
+      },
+      {
+        userId: 'user4',
+        appId: 'WEBSITE',
+        updatedAt: '2020-02-06T00:00:00.000Z',
       },
     ],
     attachmentUrl: '',

--- a/src/graphql/queries/__fixtures__/ListArticles.js
+++ b/src/graphql/queries/__fixtures__/ListArticles.js
@@ -55,7 +55,17 @@ export default {
       {
         userId: 'user2',
         appId: 'WEBSITE',
-        updatedAt: '2020-02-05T14:41:19.044Z',
+        updatedAt: '2020-02-09T14:41:19.044Z',
+      },
+      {
+        userId: 'user3',
+        appId: 'WEBSITE',
+        updatedAt: '2020-02-08T14:41:19.044Z',
+      },
+      {
+        userId: 'user4',
+        appId: 'WEBSITE',
+        updatedAt: '2020-02-07T14:41:19.044Z',
       },
     ],
     attachmentUrl: '',
@@ -122,16 +132,6 @@ export default {
         userId: 'user1',
         appId: 'WEBSITE',
         updatedAt: '2020-02-04T15:11:04.472Z',
-      },
-      {
-        userId: 'user3',
-        appId: 'WEBSITE',
-        updatedAt: '2020-02-08T14:41:19.044Z',
-      },
-      {
-        userId: 'user4',
-        appId: 'WEBSITE',
-        updatedAt: '2020-02-06T00:00:00.000Z',
       },
     ],
     attachmentUrl: '',

--- a/src/graphql/queries/__tests__/ListArticles.js
+++ b/src/graphql/queries/__tests__/ListArticles.js
@@ -885,12 +885,32 @@ describe('ListArticles', () => {
     ).toMatchSnapshot('do not have articleReply from user1');
   });
 
-  it('filters via articleContributesFrom', async () => {
+  it('filters via transcribedBy', async () => {
+    expect(
+      await gql`
+        {
+          ListArticles(filter: { transcribedBy: { userId: "user1" } }) {
+            edges {
+              node {
+                id
+                contributors {
+                  user {
+                    id
+                  }
+                }
+                transcribedAt
+              }
+            }
+          }
+        }
+      `({}, { appId: 'WEBSITE' })
+    ).toMatchSnapshot('transcribedBy user1');
+
     expect(
       await gql`
         {
           ListArticles(
-            filter: { articleContributesFrom: { userId: "user1" } }
+            filter: { transcribedBy: { userId: "user1", exists: false } }
           ) {
             edges {
               node {
@@ -906,7 +926,7 @@ describe('ListArticles', () => {
           }
         }
       `({}, { appId: 'WEBSITE' })
-    ).toMatchSnapshot('articleContributesFrom from user1');
+    ).toMatchSnapshot('is not transcribedBy user1');
   });
 
   it('filters by reply types', async () => {

--- a/src/graphql/queries/__tests__/ListArticles.js
+++ b/src/graphql/queries/__tests__/ListArticles.js
@@ -885,6 +885,30 @@ describe('ListArticles', () => {
     ).toMatchSnapshot('do not have articleReply from user1');
   });
 
+  it('filters via articleContributesFrom', async () => {
+    expect(
+      await gql`
+        {
+          ListArticles(
+            filter: { articleContributesFrom: { userId: "user1" } }
+          ) {
+            edges {
+              node {
+                id
+                contributors {
+                  user {
+                    id
+                  }
+                }
+                transcribedAt
+              }
+            }
+          }
+        }
+      `({}, { appId: 'WEBSITE' })
+    ).toMatchSnapshot('articleContributesFrom from user1');
+  });
+
   it('filters by reply types', async () => {
     expect(
       await gql`

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
@@ -709,7 +709,53 @@ Object {
 }
 `;
 
-exports[`ListArticles filters via articleContributesFrom: articleContributesFrom from user1 1`] = `
+exports[`ListArticles filters via transcribedBy: is not transcribedBy user1 1`] = `
+Object {
+  "data": Object {
+    "ListArticles": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "contributors": Array [],
+            "id": "listArticleTest7",
+            "transcribedAt": null,
+          },
+        },
+        Object {
+          "node": Object {
+            "contributors": Array [],
+            "id": "listArticleTest6",
+            "transcribedAt": null,
+          },
+        },
+        Object {
+          "node": Object {
+            "contributors": Array [],
+            "id": "listArticleTest5",
+            "transcribedAt": null,
+          },
+        },
+        Object {
+          "node": Object {
+            "contributors": Array [],
+            "id": "listArticleTest4",
+            "transcribedAt": null,
+          },
+        },
+        Object {
+          "node": Object {
+            "contributors": Array [],
+            "id": "listArticleTest3",
+            "transcribedAt": null,
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
+exports[`ListArticles filters via transcribedBy: transcribedBy user1 1`] = `
 Object {
   "data": Object {
     "ListArticles": Object {
@@ -722,19 +768,9 @@ Object {
                   "id": "user1",
                 },
               },
-              Object {
-                "user": Object {
-                  "id": "user3",
-                },
-              },
-              Object {
-                "user": Object {
-                  "id": "user4",
-                },
-              },
             ],
             "id": "listArticleTest2",
-            "transcribedAt": "2020-02-08T14:41:19.044Z",
+            "transcribedAt": "2020-02-04T15:11:04.472Z",
           },
         },
         Object {
@@ -750,9 +786,19 @@ Object {
                   "id": "user2",
                 },
               },
+              Object {
+                "user": Object {
+                  "id": "user3",
+                },
+              },
+              Object {
+                "user": Object {
+                  "id": "user4",
+                },
+              },
             ],
             "id": "listArticleTest1",
-            "transcribedAt": "2020-02-05T14:41:19.044Z",
+            "transcribedAt": "2020-02-09T14:41:19.044Z",
           },
         },
       ],

--- a/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListArticles.js.snap
@@ -709,6 +709,58 @@ Object {
 }
 `;
 
+exports[`ListArticles filters via articleContributesFrom: articleContributesFrom from user1 1`] = `
+Object {
+  "data": Object {
+    "ListArticles": Object {
+      "edges": Array [
+        Object {
+          "node": Object {
+            "contributors": Array [
+              Object {
+                "user": Object {
+                  "id": "user1",
+                },
+              },
+              Object {
+                "user": Object {
+                  "id": "user3",
+                },
+              },
+              Object {
+                "user": Object {
+                  "id": "user4",
+                },
+              },
+            ],
+            "id": "listArticleTest2",
+            "transcribedAt": "2020-02-08T14:41:19.044Z",
+          },
+        },
+        Object {
+          "node": Object {
+            "contributors": Array [
+              Object {
+                "user": Object {
+                  "id": "user1",
+                },
+              },
+              Object {
+                "user": Object {
+                  "id": "user2",
+                },
+              },
+            ],
+            "id": "listArticleTest1",
+            "transcribedAt": "2020-02-05T14:41:19.044Z",
+          },
+        },
+      ],
+    },
+  },
+}
+`;
+
 exports[`ListArticles filters via articleRepliesFrom: do not have articleReply from user1 1`] = `
 Object {
   "data": Object {

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -103,6 +103,23 @@ export const moreLikeThisInput = new GraphQLInputObjectType({
   },
 });
 
+export const userAndExistInput = new GraphQLInputObjectType({
+  name: 'UserAndExistInput',
+  fields: {
+    userId: {
+      type: new GraphQLNonNull(GraphQLString),
+    },
+    exists: {
+      type: GraphQLBoolean,
+      defaultValue: true,
+      description: `
+        When true (or not specified), return only entries with the specified user's involvement.
+        When false, return only entries that the specified user did not involve.
+      `,
+    },
+  },
+});
+
 export function createFilterType(typeName, args) {
   const filterType = new GraphQLInputObjectType({
     name: typeName,


### PR DESCRIPTION
### Changes
- Added `contributors` as a nested object in article that includes following fields :
  - https://github.com/cofacts/rumors-db/pull/67 
  - `userId`
  - `appId`
  - `updatedAt`
- Added `article.transcribedAt` which returns the latest value of `contributors.updatedAt`
- ListArticles can filter by `contributors.userId`

Reference : https://g0v.hackmd.io/OhGIQzoxR5eF6audQuS_FQ#articles

### Snapshot
![Playground - http___localhost_5000_graphql · 1 51pm · 03-18](https://github.com/cofacts/rumors-api/assets/6376572/fe1acbd7-900f-41e0-b477-c6fb65112ba0)
Note: UserDB does not contain user: ai-transcript, so it returns null.
