### PR TITLE
fix(graphql): ListCooccurrences API error

### DIFF
--- a/src/graphql/queries/ListCooccurrences.js
+++ b/src/graphql/queries/ListCooccurrences.js
@@ -30,10 +30,7 @@ export default {
   },
   async resolve(rootValue, { orderBy = [], filter = {}, ...otherParams }) {
     const body = {
-      sort: getSortArgs(orderBy, {
-        vote: (o) => ({ score: { order: o } }),
-      }),
-      track_scores: true, // for _score sorting
+      sort: getSortArgs(orderBy),
     };
 
     const filterQueries = [];
@@ -51,7 +48,6 @@ export default {
     body.query = {
       bool: {
         filter: filterQueries,
-        minimum_should_match: 1, // At least 1 "should" query should present
       },
     };
 

--- a/src/graphql/queries/__tests__/ListCooccurrences.js
+++ b/src/graphql/queries/__tests__/ListCooccurrences.js
@@ -2,7 +2,7 @@ import gql from 'util/GraphQL';
 import { loadFixtures, unloadFixtures } from 'util/fixtures';
 import fixtures from '../__fixtures__/ListCooccurrences';
 
-describe('ListArticles', () => {
+describe('ListCooccurrences', () => {
   beforeAll(() => loadFixtures(fixtures));
 
   it('lists all cooccurrences', async () => {
@@ -47,6 +47,42 @@ describe('ListArticles', () => {
         }
       `()
     ).toMatchSnapshot('by updatedAt DESC');
+  });
+
+  it('filters', async () => {
+    expect(
+      await gql`
+        {
+          ListCooccurrences(
+            filter: { updatedAt: { GT: "2020-02-03T00:01:05.000Z" } }
+          ) {
+            edges {
+              node {
+                id
+                updatedAt
+              }
+            }
+            totalCount
+          }
+        }
+      `()
+    ).toMatchInlineSnapshot(`
+      Object {
+        "data": Object {
+          "ListCooccurrences": Object {
+            "edges": Array [
+              Object {
+                "node": Object {
+                  "id": "listCooccurrenceTest2",
+                  "updatedAt": "2020-02-03T00:02:00.000Z",
+                },
+              },
+            ],
+            "totalCount": 1,
+          },
+        },
+      }
+    `);
   });
 
   afterAll(() => unloadFixtures(fixtures));

--- a/src/graphql/queries/__tests__/__snapshots__/ListCooccurrences.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/ListCooccurrences.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ListArticles lists all cooccurrences 1`] = `
+exports[`ListCooccurrences lists all cooccurrences 1`] = `
 Object {
   "data": Object {
     "ListCooccurrences": Object {
@@ -28,7 +28,7 @@ Object {
 }
 `;
 
-exports[`ListArticles sorts: by updatedAt DESC 1`] = `
+exports[`ListCooccurrences sorts: by updatedAt DESC 1`] = `
 Object {
   "data": Object {
     "ListCooccurrences": Object {


### PR DESCRIPTION
When debugging cooccurrence issue, I found bug in `ListCooccurrences` API.
The API is almost just for debugging purpose, though.

- `minumim_should_match` on queries with no should query causes 0 result when filter is set
- remove unused sort-vote logic