### PR TITLE
fix: add refresh when inserting media article

### DIFF
--- a/src/graphql/mutations/CreateMediaArticle.js
+++ b/src/graphql/mutations/CreateMediaArticle.js
@@ -165,6 +165,7 @@ async function createNewMediaArticle({
       status: getContentDefaultStatus(user),
       contributors: [],
     },
+    refresh: 'true', // Many use cases would search after media creation, thus refresh here
   });
 
   return articleId;


### PR DESCRIPTION
So that the article can be searched right after insertion.

This is to fix the issue found during 20240916 test.

Analysis: https://g0v.hackmd.io/UHKMm7h_QIe5EB4Z0cGQ3g?view#nonumpa-%E7%9A%84-grouping-issue

## After fix is applied

LINE bot sending 4 images (2 new, 2 existing)
![image](https://github.com/user-attachments/assets/91299cb4-b973-449b-a86f-75c08828572c)

Cooccurrence can now be correctly grouped
![image](https://github.com/user-attachments/assets/19f5e097-ee14-487a-8d29-f6e639d821d7)
