### PR TITLE
fix(scripts): fix top-level await issue

### DIFF
--- a/src/scripts/blockUser.ts
+++ b/src/scripts/blockUser.ts
@@ -332,7 +332,7 @@ export default main;
 
 /* istanbul ignore if */
 if (require.main === module) {
-  const argv = await yargs
+  const argv = yargs
     .options({
       userId: {
         alias: 'u',
@@ -349,5 +349,7 @@ if (require.main === module) {
     })
     .help('help').argv;
 
-  main(argv).catch(console.error);
+  // yargs is typed as a  promise for some reason, make Typescript happy here
+  //
+  Promise.resolve(argv).then(main).catch(console.error);
 }


### PR DESCRIPTION
In previous PR #338 we added `await` to `yargs` in `blockUser` script. This is causing the following error when script is being executed:

> nodejs SyntaxError: await is only valid in async functions and the top level bodies of modules

The type of `yargs` is somehow `Sth | Promise<Sth>` hence the `await`. We try to use `Promise.resolve().then()` to tackle this.