### PR TITLE
[Trivial] fix(Dockerfile): copy adm/README as it is read in adm-api startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ ENTRYPOINT NODE_ENV=production npm start
 COPY --from=builder /srv/www/node_modules ./node_modules
 COPY --from=builder /srv/www/build ./build
 COPY src/jade ./build/jade
+COPY src/adm/README.md ./build/adm/README.md
 COPY src/util/protobuf ./build/util/protobuf
 COPY package.json package-lock.json ecosystem.config.js ./
 COPY static ./static


### PR DESCRIPTION
Currently Admin API cannot start on staging due to the fact that README is not included in docker.

This PR fixes the issue and makes API available on staging.