### PR TITLE
Adjust LLM parameters to speed things up

### DIFF
--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -856,7 +856,12 @@ function extractTextFromFullTextAnnotation(fullTextAnnotation) {
     .join('');
 }
 
-const TRANSCRIPT_MODELS = ['gemini-2.0-flash-001', 'gemini-1.5-pro-002'];
+const TRANSCRIPT_MODELS = [
+  'gemini-1.5-pro-002',
+  'gemini-1.5-flash-002',
+  // 'gemini-2.0-flash-001',
+  // 'gemini-2.0-flash-lite-preview-02-05',
+];
 
 /**
  * @param {object} queryInfo - contains type and media entry ID of contents after fileUrl
@@ -1008,7 +1013,8 @@ Your text will be used for indexing these media files, so please follow these ru
 
         const vertexAI = new VertexAI({
           project: await new GoogleAuth().getProjectId(),
-          location: 'us-west1', // Nearest to Taiwan that has Gemini 2.0
+          location: 'asia-east1',
+          // location: 'us-west1', // Nearest to Taiwan that has Gemini 2.0
         });
         for (const model of TRANSCRIPT_MODELS) {
           try {

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -857,10 +857,23 @@ function extractTextFromFullTextAnnotation(fullTextAnnotation) {
 }
 
 const TRANSCRIPT_MODELS = [
-  'gemini-1.5-pro-002',
-  'gemini-1.5-flash-002',
-  // 'gemini-2.0-flash-001',
-  // 'gemini-2.0-flash-lite-preview-02-05',
+  {
+    model: 'gemini-1.5-pro-002',
+    location: 'asia-east1'
+  },
+  {
+    model: 'gemini-1.5-flash-002',
+    location: 'asia-east1'
+  },
+  // Commented models can be added back with their locations when needed
+  // {
+  //   model: 'gemini-2.0-flash-001',
+  //   location: 'us-west1'  
+  // },
+  // {
+  //   model: 'gemini-2.0-flash-lite-preview-02-05',
+  //   location: 'us-west1'
+  // }
 ];
 
 /**
@@ -1011,13 +1024,12 @@ Your text will be used for indexing these media files, so please follow these ru
           }),
         });
 
-        const vertexAI = new VertexAI({
-          project: await new GoogleAuth().getProjectId(),
-          location: 'asia-east1',
-          // location: 'us-west1', // Nearest to Taiwan that has Gemini 2.0
-        });
-        for (const model of TRANSCRIPT_MODELS) {
+        for (const { model, location } of TRANSCRIPT_MODELS) {
           try {
+            const vertexAI = new VertexAI({
+              project: await new GoogleAuth().getProjectId(),
+              location,
+            });
             const geminiModel = vertexAI.getGenerativeModel({ model });
 
             const { response } = await geminiModel.generateContent(

--- a/src/graphql/util.js
+++ b/src/graphql/util.js
@@ -859,16 +859,16 @@ function extractTextFromFullTextAnnotation(fullTextAnnotation) {
 const TRANSCRIPT_MODELS = [
   {
     model: 'gemini-1.5-pro-002',
-    location: 'asia-east1'
+    location: 'asia-east1',
   },
   {
     model: 'gemini-1.5-flash-002',
-    location: 'asia-east1'
+    location: 'asia-east1',
   },
   // Commented models can be added back with their locations when needed
   // {
   //   model: 'gemini-2.0-flash-001',
-  //   location: 'us-west1'  
+  //   location: 'us-west1'
   // },
   // {
   //   model: 'gemini-2.0-flash-lite-preview-02-05',


### PR DESCRIPTION
The most recent model, `gemini-2.0-flash-001`, suffers from slow response issue, compared to its predecessor, the experimental `gemini-2.0-flash-exp`.
![圖片](https://github.com/user-attachments/assets/a9a9a886-8a73-4d4d-a197-9f6bec78b60e)

On the other hand, I found that `gemini-1.5-pro-002` in `asia-east1` (Taiwan) and `asia-northeast1` (Tokyo) is actually as fast as `gemini-2.0-flash-exp` on `us-cental1`, and its quality is also pretty good.
![圖片](https://github.com/user-attachments/assets/b7652d65-f903-41bb-8daa-d5b2822d6125)

This PR sets up the LLM model settings for LLM transcript to prioritize `gemini-1.5-pro-002` in Asia, then  `gemini-2.0-flash-exp`. For now, we ignore the latest `gemini-2.0-flash-001` until it gets a significant speed boost.