### PR TITLE
Fix /openapi.json cannot be fetched issue

### DIFF
--- a/src/adm/util.ts
+++ b/src/adm/util.ts
@@ -98,14 +98,13 @@ export function useAuth(): RouterPlugin<any, any> {
 export function useAuditLog(): RouterPlugin<any, any> {
   return {
     async onRequest({ request }) {
-      // Skip logging for GET requests
-      if (request.method === 'GET') return;
-
       const { url, user, userId } = request;
       const shouldIncludeBody =
-        'common_name' in (request.user ?? {}) /* Called via service tokens */ ||
-        request.headers.get('content-type') ===
-          'application/json'; /* Probably from Swagger UI */
+        request.method !== 'GET' &&
+        ('common_name' in
+          (request.user ?? {}) /* Called via service tokens */ ||
+          request.headers.get('content-type') ===
+            'application/json'); /* Probably from Swagger UI */
 
       logger.info(
         {
@@ -125,9 +124,6 @@ export function useAuditLog(): RouterPlugin<any, any> {
     },
 
     async onResponse({ request, response }) {
-      // Skip logging for GET requests
-      if (request.method === 'GET') return;
-
       const shouldIncludeBody =
         response.ok &&
         (response.headers.get('content-type') ?? '').startsWith(

--- a/src/adm/util.ts
+++ b/src/adm/util.ts
@@ -98,6 +98,9 @@ export function useAuth(): RouterPlugin<any, any> {
 export function useAuditLog(): RouterPlugin<any, any> {
   return {
     async onRequest({ request }) {
+      // Skip logging for GET requests
+      if (request.method === 'GET') return;
+
       const { url, user, userId } = request;
       const shouldIncludeBody =
         'common_name' in (request.user ?? {}) /* Called via service tokens */ ||
@@ -122,6 +125,9 @@ export function useAuditLog(): RouterPlugin<any, any> {
     },
 
     async onResponse({ request, response }) {
+      // Skip logging for GET requests
+      if (request.method === 'GET') return;
+
       const shouldIncludeBody =
         response.ok &&
         (response.headers.get('content-type') ?? '').startsWith(


### PR DESCRIPTION
Currently fetching admin-api's `/openapi.json` with service token will be blocked.

The root cause is that `shouldIncludeBody` is always true when called via service tokens, so that GET requests to `/openapi.json` always fails with invalid JSON in the following statement:
```json
shouldIncludeBody ? await request.json() : undefined
```

Because GET requests don't have body.

This PR fixes the issue by don't include the request body in audit log for GET requests.