### PR TITLE
feat(admin): Implement moderation API endpoints for media and AI reply

### DIFF
--- a/src/adm/handlers/moderation/genAIReply.ts
+++ b/src/adm/handlers/moderation/genAIReply.ts
@@ -1,0 +1,49 @@
+import { HTTPError } from 'fets';
+import genAIReplyScript from 'scripts/genAIReply';
+type GenAIReplyParams = {
+  articleId: string;
+  temperature?: number;
+};
+
+/**
+ * Calls the genAIReply script to generate a new AI reply for the specified article.
+ * Returns { success: true } if the script runs without throwing an error.
+ */
+async function genAIReplyHandler({
+  articleId,
+  temperature,
+}: GenAIReplyParams): Promise<{ success: boolean }> {
+  try {
+    // The script handles fetching the article and user creation internally.
+    // It returns the AI response doc or null if content is insufficient.
+    // We only care if it throws an error or not.
+    await genAIReplyScript({ articleId, temperature });
+
+    // If the script completes without error, consider it a success.
+    return { success: true };
+  } catch (e: any) {
+    // Handle known errors, e.g., article not found by the script
+    if (e.message.includes('Please specify articleId')) {
+      // This specific error is unlikely if articleId is required by schema, but good practice
+      throw new HTTPError(400, e.message);
+    }
+    if (
+      e.message.includes('document_missing_exception') ||
+      e.message.includes('not found')
+    ) {
+      // Error from client.get inside the script if article doesn't exist
+      throw new HTTPError(404, `Article with ID=${articleId} not found.`);
+    }
+
+    // Log and re-throw unknown errors
+    console.error('[genAIReplyHandler] Unexpected error:', e);
+    throw new HTTPError(
+      500,
+      `Error generating AI reply for article ${articleId}: ${
+        e.message || 'Unknown error'
+      }`
+    );
+  }
+}
+
+export default genAIReplyHandler;

--- a/src/adm/handlers/moderation/replaceMedia.ts
+++ b/src/adm/handlers/moderation/replaceMedia.ts
@@ -1,0 +1,55 @@
+import { HTTPError } from 'fets';
+import replaceMediaScript from 'scripts/replaceMedia';
+import client from 'util/client'; // Moved to top
+
+type ReplaceMediaParams = {
+  articleId: string;
+  url: string;
+  force?: boolean;
+};
+
+async function replaceMediaHandler({
+  articleId,
+  url,
+  force = false,
+}: ReplaceMediaParams): Promise<{ attachmentHash: string }> {
+  try {
+    // The original script logs the new hash but doesn't return it.
+    // We'll run the script and then fetch the article again to get the updated hash.
+    await replaceMediaScript({ articleId, url, force });
+
+    const {
+      body: { _source: updatedArticle },
+    } = await client.get({ index: 'articles', type: 'doc', id: articleId });
+
+    if (!updatedArticle) {
+      // This case might happen if the article was deleted between the script run and the fetch
+      throw new HTTPError(
+        404,
+        `Article ${articleId} not found after update attempt.`
+      );
+    }
+
+    return { attachmentHash: updatedArticle.attachmentHash };
+  } catch (e: any) {
+    // Handle known errors from the script or client
+    if (e.message.includes('not found')) {
+      // Could be article not found initially, or after update attempt
+      throw new HTTPError(404, e.message);
+    }
+    if (e.message.includes('has no corresponding media entry') && !force) {
+      // Error from replaceMediaScript if old media entry is missing and force=false
+      throw new HTTPError(400, e.message);
+    }
+    // Re-throw unknown errors after logging
+    console.error('[replaceMediaHandler] Unexpected error:', e);
+    throw new HTTPError(
+      500,
+      `Error replacing media for article ${articleId}: ${
+        e.message || 'Unknown error'
+      }`
+    );
+  }
+}
+
+export default replaceMediaHandler;

--- a/src/adm/index.ts
+++ b/src/adm/index.ts
@@ -139,7 +139,6 @@ const router = createRouter({
             }),
             url: Type.String({
               description: 'The URL pointing to the new media content',
-              format: 'uri', // Add format validation for URL
             }),
             force: Type.Optional(
               Type.Boolean({

--- a/src/adm/index.ts
+++ b/src/adm/index.ts
@@ -12,6 +12,7 @@ import pingHandler from './handlers/ping';
 import blockUser from './handlers/moderation/blockUser';
 import awardBadge from './handlers/badge/awardBadge';
 import replaceMediaHandler from './handlers/moderation/replaceMedia';
+import genAIReplyHandler from './handlers/moderation/genAIReply';
 
 const shouldAuth = process.env.NODE_ENV === 'production';
 
@@ -168,6 +169,49 @@ const router = createRouter({
     },
     handler: async (request) =>
       Response.json(await replaceMediaHandler(await request.json())),
+  })
+  .route({
+    method: 'POST',
+    path: '/moderation/aiReply',
+    description:
+      'Generate a new AI reply for the specified article, replacing any existing one.',
+    schemas: {
+      request: {
+        json: Type.Object(
+          {
+            articleId: Type.String({
+              description: 'The ID of the article to generate an AI reply for',
+            }),
+            temperature: Type.Optional(
+              Type.Number({
+                description:
+                  'OpenAI temperature setting (0-2). Higher values make the output more random.',
+                minimum: 0,
+                maximum: 2,
+              })
+            ),
+          },
+          { additionalProperties: false }
+        ),
+      },
+      responses: {
+        200: Type.Object(
+          {
+            success: Type.Boolean({
+              description:
+                'Indicates if the AI reply generation was initiated successfully.',
+            }),
+          },
+          { additionalProperties: false }
+        ),
+        // Add potential error responses based on the handler
+        400: Type.Object({ message: Type.String() }), // e.g., invalid input
+        404: Type.Object({ message: Type.String() }), // e.g., article not found
+        500: Type.Object({ message: Type.String() }), // Internal server error during generation
+      },
+    },
+    handler: async (request) =>
+      Response.json(await genAIReplyHandler(await request.json())),
   });
 
 createServer(router).listen(process.env.ADM_PORT, () => {


### PR DESCRIPTION
Implements Phase 1 moderation endpoints as described in the design document:

- Adds `/moderation/article/media` endpoint to replace article media using the `replaceMedia.js` script. 
![圖片](https://github.com/user-attachments/assets/5232a9ab-8933-45a1-a8e7-4d0221adaed1)
- Adds `/moderation/aiReply` endpoint to regenerate AI replies using the `genAIReply.js` script. 
![圖片](https://github.com/user-attachments/assets/ae2c9985-8078-4b94-8f03-fccc55587885)

These endpoints complete the planned functionality for Phase 1 of the spam removal automation system.

**Related:**
- Design Doc: https://g0v.hackmd.io/@cofacts/HJlJCpfZA

