### PR TITLE
Fix/graphiql cdn links

### DIFF
--- a/static/graphiql.html
+++ b/static/graphiql.html
@@ -36,14 +36,14 @@
       copy them directly into your environment, or perhaps include them in your
       favored resource bundler.
      -->
-    <script src="https://unpkg.com/graphiql/graphiql.min.js" type="application/javascript"></script>
-    <link rel="stylesheet" href="https://unpkg.com/graphiql/graphiql.min.css" />
+    <script src="https://unpkg.com/graphiql@5.0.0/dist/GraphiQL.js" type="application/javascript"></script>
+    <link rel="stylesheet" href="https://unpkg.com/graphiql@5.0.0/dist/style.css" />
     <!-- 
       These are imports for the GraphIQL Explorer plugin.
      -->
-    <script src="https://unpkg.com/@graphiql/plugin-explorer/dist/index.umd.js" crossorigin></script>
+    <script src="https://unpkg.com/@graphiql/plugin-explorer@5.0.0/dist/index.js" crossorigin></script>
 
-    <link rel="stylesheet" href="https://unpkg.com/@graphiql/plugin-explorer/dist/style.css" />
+    <link rel="stylesheet" href="https://unpkg.com/@graphiql/plugin-explorer@5.0.0/dist/style.css" />
 </head>
 
 <body>

--- a/static/graphiql.html
+++ b/static/graphiql.html
@@ -1,5 +1,5 @@
 <!--
- *  Copyright (c) 2021 GraphQL Contributors
+ *  Copyright (c) 2025 GraphQL Contributors
  *  All rights reserved.
  *
  *  This source code is licensed under the license found in the
@@ -9,6 +9,8 @@
 <html lang="en">
 
 <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>GraphiQL</title>
     <style>
         body {
@@ -21,48 +23,84 @@
         #graphiql {
             height: 100vh;
         }
-    </style>
-    <!--
-      This GraphiQL example depends on Promise and fetch, which are available in
-      modern browsers, but can be "polyfilled" for older browsers.
-      GraphiQL itself depends on React DOM.
-      If you do not want to rely on a CDN, you can host these files locally or
-      include them directly in your favored resource bundler.
-    -->
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
-    <!--
-      These two files can be found in the npm module, however you may wish to
-      copy them directly into your environment, or perhaps include them in your
-      favored resource bundler.
-     -->
-    <script src="https://unpkg.com/graphiql@5.0.0/dist/GraphiQL.js" type="application/javascript"></script>
-    <link rel="stylesheet" href="https://unpkg.com/graphiql@5.0.0/dist/style.css" />
-    <!-- 
-      These are imports for the GraphIQL Explorer plugin.
-     -->
-    <script src="https://unpkg.com/@graphiql/plugin-explorer@5.0.0/dist/index.js" crossorigin></script>
 
-    <link rel="stylesheet" href="https://unpkg.com/@graphiql/plugin-explorer@5.0.0/dist/style.css" />
+        .loading { /* Copied from official example */
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 4rem;
+        }
+    </style>
+    <link rel="stylesheet" href="https://esm.sh/graphiql/dist/style.css" />
+    <link rel="stylesheet" href="https://esm.sh/@graphiql/plugin-explorer/dist/style.css" />
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "https://esm.sh/react@19.1.0",
+          "react/jsx-runtime": "https://esm.sh/react@19.1.0/jsx-runtime",
+
+          "react-dom": "https://esm.sh/react-dom@19.1.0",
+          "react-dom/client": "https://esm.sh/react-dom@19.1.0/client",
+
+          "graphiql": "https://esm.sh/graphiql?standalone&external=react,react-dom,@graphiql/react,graphql",
+          "@graphiql/plugin-explorer": "https://esm.sh/@graphiql/plugin-explorer?standalone&external=react,@graphiql/react,graphql",
+          "@graphiql/react": "https://esm.sh/@graphiql/react?standalone&external=react,react-dom,graphql",
+
+          "@graphiql/toolkit": "https://esm.sh/@graphiql/toolkit?standalone&external=graphql",
+          "graphql": "https://esm.sh/graphql@16.11.0"
+        }
+      }
+    </script>
+    <script type="module">
+      import React from 'react';
+      import ReactDOM from 'react-dom/client';
+      import { GraphiQL } from 'graphiql';
+      import { createGraphiQLFetcher } from '@graphiql/toolkit';
+      import { explorerPlugin } from '@graphiql/plugin-explorer';
+
+      import createJSONWorker from 'https://esm.sh/monaco-editor/esm/vs/language/json/json.worker.js?worker';
+      import createGraphQLWorker from 'https://esm.sh/monaco-graphql/esm/graphql.worker.js?worker';
+      import createEditorWorker from 'https://esm.sh/monaco-editor/esm/vs/editor/editor.worker.js?worker';
+
+      globalThis.MonacoEnvironment = {
+        getWorker(_workerId, label) {
+          switch (label) {
+            case 'json':
+              return createJSONWorker();
+            case 'graphql':
+              return createGraphQLWorker();
+          }
+          return createEditorWorker();
+        },
+      };
+
+      const fetcher = createGraphiQLFetcher({
+        url: './graphql', // Original URL from this project
+        headers: { 'X-Example-Header': 'foo' }, // Header from original local file
+      });
+
+      const explorer = explorerPlugin();
+      const plugins = [explorer];
+
+      function App() {
+        return React.createElement(GraphiQL, {
+          fetcher,
+          plugins,
+          defaultEditorToolsVisibility: true, // From original local file
+        });
+      }
+
+      const container = document.getElementById('graphiql');
+      const root = ReactDOM.createRoot(container);
+      root.render(React.createElement(App));
+    </script>
 </head>
 
 <body>
-    <div id="graphiql">Loading...</div>
-    <script>
-        const root = ReactDOM.createRoot(document.getElementById('graphiql'));
-        const fetcher = GraphiQL.createFetcher({
-            url: './graphql',
-            headers: { 'X-Example-Header': 'foo' },
-        });
-        const explorerPlugin = GraphiQLPluginExplorer.explorerPlugin();
-        root.render(
-            React.createElement(GraphiQL, {
-                fetcher,
-                defaultEditorToolsVisibility: true,
-                plugins: [explorerPlugin],
-            }),
-        );
-    </script>
+    <div id="graphiql">
+        <div class="loading">Loading…</div> <!-- Loading message from official example -->
+    </div>
 </body>
 
 </html>


### PR DESCRIPTION
GraphiQL upgrades to v5. This caused 2 issues:
- unpkg cannot load v5 correctly, 404 is returned
- even if unpkg loads, graphiql v5 requires Monaco's worker to work properly (Ref: https://github.com/graphql/graphiql/issues/4033#issuecomment-2999455605 )

This PR refers to [the official CDN example](https://github.com/graphql/graphiql/blob/main/examples/graphiql-cdn/index.html) to fix the GraphiQL