### PR TITLE
fix: include babel.config.js in Docker build and exclude test files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 *
 !.babelrc
+!babel.config.js
 !ecosystem.config.js
 !package.json
 !package-lock.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN npm install
 #
 COPY . .
 
-RUN node_modules/.bin/babel src -d build --extensions ".ts,.js"
+RUN node_modules/.bin/babel src -d build --extensions ".ts,.js" --ignore "**/__fixtures__/**" --ignore "**/__tests__/**"
 RUN npm prune --production
 
 #########################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN npm install
 #
 COPY . .
 
-RUN node_modules/.bin/babel src -d build --extensions ".ts,.js" --ignore "**/__fixtures__/**" --ignore "**/__tests__/**"
+RUN node_modules/.bin/babel src -d build --extensions ".ts,.js" --ignore "**/__tests__/**,**/__fixtures__/**"
 RUN npm prune --production
 
 #########################################


### PR DESCRIPTION
## Summary

- Add `!babel.config.js` to `.dockerignore` — the project migrated from `.babelrc` to `babel.config.js` in #381, but `.dockerignore` only whitelisted `.babelrc`. This caused Docker builds to run Babel **without** the TypeScript preset, failing on all `.ts` files.
- Use comma-separated `--ignore` pattern to exclude `__tests__` and `__fixtures__` from the production Babel build (fixes the syntax noted in #382's review comment).

## Context

Fixes the `build-and-push` CI failure after merging #381. The root cause was `babel.config.js` being excluded by `.dockerignore`, so Babel ran without `@babel/preset-typescript` inside Docker. This was a latent bug that only surfaced when `.ts` source files were added.

Supersedes #382 which only addressed the `--ignore` flag but missed the `.dockerignore` fix.