### PR TITLE
ci: skip duplicate runs for internal PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
 
 jobs:
   install-and-test:
+    # Only run on "pull_request" event for external PRs. This is to avoid
+    # duplicate builds for PRs created from internal branches.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     runs-on: ubuntu-latest
     services:
       rumors-test-db:


### PR DESCRIPTION
## Problem

When a commit is pushed to a PR branch, GitHub triggers both the `push` and
`pull_request` events simultaneously, running CI twice on identical code —
wasting resources and doubling queue time.

## Fix

Add an `if` condition to the job to skip the `pull_request` run for internal
branches (where a `push` run already covers it):

```yaml
if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
```

**How it works:**
- Internal branch PR: `push` event runs, `pull_request` event is **skipped** → no duplicate
- Fork PR: `push` event doesn't trigger on the upstream repo, `pull_request` event **runs** → fork contributors still get CI
- Direct branch push (no open PR): `push` event runs as usual

Used by: [cloudflare/quiche](https://github.com/cloudflare/quiche/blob/master/.github/workflows/stable.yml),
[briansmith/ring](https://github.com/briansmith/ring/blob/main/.github/workflows/ci.yml),
[kubernetes-sigs/kubebuilder](https://github.com/kubernetes-sigs/kubebuilder/blob/master/.github/workflows/verify-all.yml)