### PR TITLE
fix(CreateMediaArticle): generate transcript when AI response is missing

### DIFF
--- a/src/graphql/mutations/CreateMediaArticle.js
+++ b/src/graphql/mutations/CreateMediaArticle.js
@@ -1,6 +1,6 @@
 import { GraphQLString, GraphQLNonNull } from 'graphql';
 import { assertUser, getContentDefaultStatus } from 'util/user';
-import { uploadMedia, getAIResponse } from 'graphql/util';
+import { uploadMedia, getAIResponse, createTranscript } from 'graphql/util';
 import client, { getTotalCount } from 'util/client';
 import { errors } from '@elastic/elasticsearch';
 import { schema } from 'prosemirror-schema-basic';
@@ -184,8 +184,16 @@ export default {
 
       // Write AI transcript to article & ydoc
       Promise.all([aritcleIdPromise, aiResponsePromise])
-        .then(([articleId, aiResponse]) => {
+        .then(async ([articleId, aiResponse]) => {
           if (!aiResponse) {
+            aiResponse = await createTranscript(
+              { id: mediaEntry.id, type: articleType.toLowerCase() },
+              mediaEntry,
+              user
+            );
+          }
+
+          if (!aiResponse || aiResponse.status !== 'SUCCESS') {
             throw new Error('AI transcript not found');
           }
 

--- a/src/graphql/mutations/CreateMediaArticle.js
+++ b/src/graphql/mutations/CreateMediaArticle.js
@@ -194,7 +194,9 @@ export default {
           }
 
           if (!aiResponse || aiResponse.status !== 'SUCCESS') {
-            throw new Error('AI transcript not found');
+            throw new Error(
+              `AI transcript failed: ${aiResponse?.text || 'Unknown error'}`
+            );
           }
 
           // Archive URLs in transcript; don't wait for it


### PR DESCRIPTION
## 問題

使用者透過 LINE bot 回報圖片時，流程如下：

1. LINE bot 呼叫 `ListArticles`（帶 `filter.transcript.shouldCreate: true`）搜尋相似文章
2. `ListArticles` 在找到相似文章且該文章有 `text` 時，會直接沿用其文字作為搜尋用 transcript，**跳過** `createTranscript`
3. LINE bot 顯示相似文章讓使用者選擇
4. 使用者選擇「找不到我想查的訊息」並提交新文章
5. `CreateMediaArticle` 執行，但找不到新圖片的 AI response → 記錄 warning `AI transcript not found`，新文章沒有逐字稿

實際案例：文章 [`R4C4c54BYvv2RuZLVYf1`](https://cofacts.tw/article/R4C4c54BYvv2RuZLVYf1) 是一張與舊文章 `GOjaQpUBYrjt7MSMDC1a`（perceptual hash 相同前綴 `zjxxxw`）相似的圖片。因舊文章 `text` 非空，`ListArticles` 跳過 `createTranscript`，新文章因此沒有逐字稿。

## 修法

在 `CreateMediaArticle` 找不到 AI response 時，直接呼叫 `createTranscript` 即時補做。

這讓「沒有逐字稿」的責任歸屬更清楚：`ListArticles` 負責搜尋，`CreateMediaArticle` 負責確保自己建立的文章有逐字稿。

## Test plan

- [ ] 回報一張與資料庫中現有圖片相似（perceptual hash 相同）但不完全一樣的圖片
- [ ] 確認新文章建立後有逐字稿（`aiTranscripts` 非空、`text` 有內容）
- [ ] 確認回報完全新的圖片（無相似文章）流程仍正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)