### PR TITLE
test(CreateMediaArticle): add createTranscript mock and fallback test

### DIFF
--- a/src/graphql/mutations/__tests__/CreateMediaArticle.js
+++ b/src/graphql/mutations/__tests__/CreateMediaArticle.js
@@ -8,15 +8,21 @@ import fixtures from '../__fixtures__/CreateMediaArticle';
 import { getReplyRequestId } from '../CreateOrUpdateReplyRequest';
 import mediaManager from 'util/mediaManager';
 import archiveUrlsFromText from 'util/archiveUrlsFromText';
+import { createTranscript } from 'graphql/util';
 
 jest.mock('util/mediaManager');
 jest.mock('util/archiveUrlsFromText', () => jest.fn(() => []));
+jest.mock('graphql/util', () => ({
+  ...jest.requireActual('graphql/util'),
+  createTranscript: jest.fn(),
+}));
 
 describe('creation', () => {
   beforeAll(() => loadFixtures(fixtures));
   beforeEach(() => {
     mediaManager.insert.mockClear();
     archiveUrlsFromText.mockClear();
+    createTranscript.mockClear();
   });
   afterAll(() => unloadFixtures(fixtures));
 
@@ -70,6 +76,9 @@ describe('creation', () => {
         ],
       ]
     `);
+
+    // Expect createTranscript is NOT called when AI response already exists
+    expect(createTranscript).not.toHaveBeenCalled();
 
     // Expect archiveUrlsFromText is called with OCR result
     expect(archiveUrlsFromText.mock.calls).toMatchInlineSnapshot(`
@@ -167,6 +176,109 @@ describe('creation', () => {
     await client.delete({
       index: 'articles',
       id: data.CreateMediaArticle.id,
+    });
+
+    await client.delete({
+      index: 'replyrequests',
+      id: replyRequestId,
+    });
+
+    await client.delete({
+      index: 'ydocs',
+      id: data.CreateMediaArticle.id,
+    });
+  });
+
+  it('calls createTranscript when no AI response exists, and writes transcript to article', async () => {
+    MockDate.set(1485593157011);
+    const userId = 'test';
+    const appId = 'foo';
+
+    mediaManager.insert.mockImplementationOnce(async () => ({
+      id: 'mock_hash_no_ai_response',
+      url: 'http://foo.com/new_image.jpeg',
+      type: 'image',
+    }));
+
+    createTranscript.mockResolvedValueOnce({
+      id: 'new-transcript-id',
+      status: 'SUCCESS',
+      text: 'Transcript from createTranscript',
+    });
+
+    const { data, errors } = await gql`
+      mutation (
+        $mediaUrl: String!
+        $articleType: ArticleTypeEnum!
+        $reference: ArticleReferenceInput!
+      ) {
+        CreateMediaArticle(
+          mediaUrl: $mediaUrl
+          articleType: $articleType
+          reference: $reference
+          reason: "test reason"
+        ) {
+          id
+        }
+      }
+    `(
+      {
+        mediaUrl: 'http://foo.com/new_image.jpeg',
+        articleType: 'IMAGE',
+        reference: { type: 'LINE' },
+      },
+      { user: { id: userId, appId } }
+    );
+    MockDate.reset();
+
+    expect(errors).toBeUndefined();
+
+    // Expect createTranscript was called with correct arguments
+    expect(createTranscript).toHaveBeenCalledWith(
+      { id: 'mock_hash_no_ai_response', type: 'image' },
+      expect.objectContaining({ id: 'mock_hash_no_ai_response' }),
+      expect.objectContaining({ id: userId })
+    );
+
+    // Expect archiveUrlsFromText is called with the transcript text
+    expect(archiveUrlsFromText.mock.calls).toMatchInlineSnapshot(`
+      Array [
+        Array [
+          "Transcript from createTranscript",
+        ],
+      ]
+    `);
+
+    const { _source: article } = await client.get({
+      index: 'articles',
+      id: data.CreateMediaArticle.id,
+    });
+
+    expect(article.text).toBe('Transcript from createTranscript');
+
+    const {
+      _source: { ydoc: encodedYdoc },
+    } = await client.get({
+      index: 'ydocs',
+      id: data.CreateMediaArticle.id,
+    });
+
+    const ydoc = new Y.Doc();
+    Y.applyUpdate(ydoc, Buffer.from(encodedYdoc, 'base64'));
+    expect(ydoc.getXmlFragment('prosemirror')).toMatchInlineSnapshot(
+      `"<paragraph>Transcript from createTranscript</paragraph>"`
+    );
+
+    // Cleanup
+    await client.delete({
+      index: 'articles',
+      id: data.CreateMediaArticle.id,
+    });
+
+    const replyRequestId = getReplyRequestId({
+      articleId: data.CreateMediaArticle.id,
+      userId,
+      appId,
     });
 
     await client.delete({

--- a/src/graphql/mutations/__tests__/CreateMediaArticle.js
+++ b/src/graphql/mutations/__tests__/CreateMediaArticle.js
@@ -8,23 +8,28 @@ import fixtures from '../__fixtures__/CreateMediaArticle';
 import { getReplyRequestId } from '../CreateOrUpdateReplyRequest';
 import mediaManager from 'util/mediaManager';
 import archiveUrlsFromText from 'util/archiveUrlsFromText';
-import { createTranscript } from 'graphql/util';
+import * as graphqlUtil from 'graphql/util';
 
 jest.mock('util/mediaManager');
 jest.mock('util/archiveUrlsFromText', () => jest.fn(() => []));
-jest.mock('graphql/util', () => ({
-  ...jest.requireActual('graphql/util'),
-  createTranscript: jest.fn(),
-}));
 
 describe('creation', () => {
-  beforeAll(() => loadFixtures(fixtures));
+  let createTranscript;
+  beforeAll(async () => {
+    createTranscript = jest
+      .spyOn(graphqlUtil, 'createTranscript')
+      .mockResolvedValue(undefined);
+    await loadFixtures(fixtures);
+  });
   beforeEach(() => {
     mediaManager.insert.mockClear();
     archiveUrlsFromText.mockClear();
     createTranscript.mockClear();
   });
-  afterAll(() => unloadFixtures(fixtures));
+  afterAll(async () => {
+    jest.restoreAllMocks();
+    await unloadFixtures(fixtures);
+  });
 
   it('creates a media article, a reply request, a ydoc and fills in OCR result', async () => {
     MockDate.set(1485593157011);

--- a/src/graphql/mutations/__tests__/CreateMediaArticle.js
+++ b/src/graphql/mutations/__tests__/CreateMediaArticle.js
@@ -193,103 +193,100 @@ describe('creation', () => {
     MockDate.set(1485593157011);
     const userId = 'test';
     const appId = 'foo';
+    let articleId;
 
-    mediaManager.insert.mockImplementationOnce(async () => ({
-      id: 'mock_hash_no_ai_response',
-      url: 'http://foo.com/new_image.jpeg',
-      type: 'image',
-    }));
+    try {
+      mediaManager.insert.mockImplementationOnce(async () => ({
+        id: 'mock_hash_no_ai_response',
+        url: 'http://foo.com/new_image.jpeg',
+        type: 'image',
+      }));
 
-    createTranscript.mockResolvedValueOnce({
-      id: 'new-transcript-id',
-      status: 'SUCCESS',
-      text: 'Transcript from createTranscript',
-    });
+      createTranscript.mockResolvedValueOnce({
+        id: 'new-transcript-id',
+        status: 'SUCCESS',
+        text: 'Transcript from createTranscript',
+      });
 
-    const { data, errors } = await gql`
-      mutation (
-        $mediaUrl: String!
-        $articleType: ArticleTypeEnum!
-        $reference: ArticleReferenceInput!
-      ) {
-        CreateMediaArticle(
-          mediaUrl: $mediaUrl
-          articleType: $articleType
-          reference: $reference
-          reason: "test reason"
+      const { data, errors } = await gql`
+        mutation (
+          $mediaUrl: String!
+          $articleType: ArticleTypeEnum!
+          $reference: ArticleReferenceInput!
         ) {
-          id
+          CreateMediaArticle(
+            mediaUrl: $mediaUrl
+            articleType: $articleType
+            reference: $reference
+            reason: "test reason"
+          ) {
+            id
+          }
         }
-      }
-    `(
-      {
-        mediaUrl: 'http://foo.com/new_image.jpeg',
-        articleType: 'IMAGE',
-        reference: { type: 'LINE' },
-      },
-      { user: { id: userId, appId } }
-    );
-    MockDate.reset();
+      `(
+        {
+          mediaUrl: 'http://foo.com/new_image.jpeg',
+          articleType: 'IMAGE',
+          reference: { type: 'LINE' },
+        },
+        { user: { id: userId, appId } }
+      );
 
-    expect(errors).toBeUndefined();
+      expect(errors).toBeUndefined();
+      articleId = data.CreateMediaArticle.id;
 
-    // Expect createTranscript was called with correct arguments
-    expect(createTranscript).toHaveBeenCalledWith(
-      { id: 'mock_hash_no_ai_response', type: 'image' },
-      expect.objectContaining({ id: 'mock_hash_no_ai_response' }),
-      expect.objectContaining({ id: userId })
-    );
+      // Expect createTranscript was called with correct arguments
+      expect(createTranscript).toHaveBeenCalledWith(
+        { id: 'mock_hash_no_ai_response', type: 'image' },
+        expect.objectContaining({ id: 'mock_hash_no_ai_response' }),
+        expect.objectContaining({ id: userId })
+      );
 
-    // Expect archiveUrlsFromText is called with the transcript text
-    expect(archiveUrlsFromText.mock.calls).toMatchInlineSnapshot(`
-      Array [
+      // Expect archiveUrlsFromText is called with the transcript text
+      expect(archiveUrlsFromText.mock.calls).toMatchInlineSnapshot(`
         Array [
-          "Transcript from createTranscript",
-        ],
-      ]
-    `);
+          Array [
+            "Transcript from createTranscript",
+          ],
+        ]
+      `);
 
-    const { _source: article } = await client.get({
-      index: 'articles',
-      id: data.CreateMediaArticle.id,
-    });
+      const { _source: article } = await client.get({
+        index: 'articles',
+        id: articleId,
+      });
 
-    expect(article.text).toBe('Transcript from createTranscript');
+      expect(article.text).toBe('Transcript from createTranscript');
 
-    const {
-      _source: { ydoc: encodedYdoc },
-    } = await client.get({
-      index: 'ydocs',
-      id: data.CreateMediaArticle.id,
-    });
+      const {
+        _source: { ydoc: encodedYdoc },
+      } = await client.get({
+        index: 'ydocs',
+        id: articleId,
+      });
 
-    const ydoc = new Y.Doc();
-    Y.applyUpdate(ydoc, Buffer.from(encodedYdoc, 'base64'));
-    expect(ydoc.getXmlFragment('prosemirror')).toMatchInlineSnapshot(
-      `"<paragraph>Transcript from createTranscript</paragraph>"`
-    );
+      const ydoc = new Y.Doc();
+      Y.applyUpdate(ydoc, Buffer.from(encodedYdoc, 'base64'));
+      expect(ydoc.getXmlFragment('prosemirror')).toMatchInlineSnapshot(
+        `"<paragraph>Transcript from createTranscript</paragraph>"`
+      );
+    } finally {
+      MockDate.reset();
 
-    // Cleanup
-    await client.delete({
-      index: 'articles',
-      id: data.CreateMediaArticle.id,
-    });
+      if (articleId) {
+        const replyRequestId = getReplyRequestId({
+          articleId,
+          userId,
+          appId,
+        });
 
-    const replyRequestId = getReplyRequestId({
-      articleId: data.CreateMediaArticle.id,
-      userId,
-      appId,
-    });
-
-    await client.delete({
-      index: 'replyrequests',
-      id: replyRequestId,
-    });
-
-    await client.delete({
-      index: 'ydocs',
-      id: data.CreateMediaArticle.id,
-    });
+        await Promise.all([
+          client.delete({ index: 'articles', id: articleId }),
+          client.delete({ index: 'replyrequests', id: replyRequestId }),
+          client.delete({ index: 'ydocs', id: articleId }),
+        ]);
+      }
+    }
   });
 
   it('avoids creating duplicated media articles and adds replyRequests automatically', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "ignoreDeprecations": "6.0",
     "baseUrl": "./",
     "paths": {
       "*": ["src/*", "test/*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "ignoreDeprecations": "6.0",
     "baseUrl": "./",
     "paths": {
       "*": ["src/*", "test/*"]


### PR DESCRIPTION
$(cat <<'EOF'
## 問題

PR #391 的 CI 有兩個問題：

### 1. TypeScript 5.9.3 把 deprecated 選項視為 error

`npm run typecheck` 失敗於：
- `TS5101`: `baseUrl` deprecated
- `TS5107`: `moduleResolution=node10` deprecated

修法：在 `tsconfig.json` 加入 `"ignoreDeprecations": "6.0"`。

### 2. Unit test 缺少 `createTranscript` 的 mock 及測試覆蓋

PR #391 加入了「當 `getAIResponse` 回傳 null 時呼叫 `createTranscript`」的邏輯，但：
- 現有 test 2（duplicate article）和 test 4（spam user）沒有 `airesponses` fixture，導致 `createTranscript` 意外被呼叫，對真實外部 API 發送請求（或留下孤立的 ES 文件）
- 新的 fallback 路徑完全沒有 unit test coverage

## 修法

1. **Mock `createTranscript`**：在 `graphql/util` 的 partial mock 中覆蓋 `createTranscript`（保留其他函數的真實實作）
2. **既有測試加入斷言**：test 1 明確斷言 `createTranscript` 未被呼叫（因為有 fixture 提供 cached response）
3. **新增測試案例**：當 `getAIResponse` 回傳 null 時，`createTranscript` 被呼叫且其結果被寫入 article text 與 ydoc

## Test plan

- [ ] `npm run typecheck` 不再出現 TS5101/TS5107 errors
- [ ] `npm run test -- --testPathPattern=CreateMediaArticle` 全部測試通過
- [ ] 新測試案例驗證 `createTranscript` fallback 路徑

https://claude.ai/code/session_01RZqToTs8oKdTqZFCTLksLt
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZqToTs8oKdTqZFCTLksLt)_