### PR TITLE
chore(deps): upgrade @cofacts/media-manager to 0.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@cofacts/media-manager": "^0.3.2",
+        "@cofacts/media-manager": "^0.3.3",
         "@elastic/elasticsearch": "^9.0.0",
         "@google-cloud/bigquery": "^6.2.0",
         "@google-cloud/vision": "^3.1.4",
@@ -231,7 +231,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2154,9 +2153,9 @@
       "license": "MIT"
     },
     "node_modules/@cofacts/media-manager": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@cofacts/media-manager/-/media-manager-0.3.2.tgz",
-      "integrity": "sha512-vKx+q1Q/JvBdRiupkxkODgDOZOo1T9bAZziYK1P2ajPZt720QKNSLqwf8rgbIzT/68QnnV8ZZEkyk5GmLgCXMQ==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@cofacts/media-manager/-/media-manager-0.3.3.tgz",
+      "integrity": "sha512-TYV+S5gHTifeDzyPNaWqQVOFH63FerLMFdxAn5co+Cwce+zFzwPyfy3pd8bj63fYwWgOiDolIriEdzp5y+hbWw==",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^6.12.0",
@@ -3675,7 +3674,6 @@
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4416,7 +4414,6 @@
       "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -4604,7 +4601,6 @@
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -5195,7 +5191,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6258,7 +6253,6 @@
       "integrity": "sha512-MlX10UDheRr3lb3P0WcaIdtCSRlxdQsB1sBqL7W0raF070bGl1HQQq5K3T2vf2XAYie+ww+5AKC/WrkjRO2knA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "find-babel-config": "^1.2.0",
         "glob": "^7.1.6",
@@ -6572,7 +6566,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8158,7 +8151,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -8333,7 +8325,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -9947,7 +9938,6 @@
       "integrity": "sha512-AT+RJgD2sH8phPmCf7OUZR8xGdcJRga4+1cOaXJ64hvcSkVhNcRHOwIxUatPH15+nj59WAGTDv3LSGZPEQbJaQ==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
-      "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
@@ -10318,7 +10308,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.10.1.tgz",
       "integrity": "sha512-BL/Xd/T9baO6NFzoMpiMD7YUZ62R6viR5tp/MULVEnbYJXZA//kRNW7J0j1w/wXArgL0sCxhDfK5dczSKn3+cg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -14555,7 +14544,6 @@
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -14681,7 +14669,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -14700,7 +14687,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -14721,7 +14707,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.4.tgz",
       "integrity": "sha512-WkKgnyjNncri03Gjaz3IFWvCAE94XoiEgvtr0/r2Xw7R8/IjK3sKLSiDoCHWcsXSAinVaKlGRZDvMCsF1kbzjA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -16927,7 +16912,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -18271,7 +18255,6 @@
       "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.28.tgz",
       "integrity": "sha512-EgnDOXs8+hBVm6mq3/S89Kiwzh5JRbn7w2wXwbrMRyKy/8dOFsLvuIfC+x19ZdtaDc0tA9rQmdZzbqqNHG44wA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lib0": "^0.2.99"
       },
@@ -18333,7 +18316,6 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "rumors-db:install": "cd src/rumors-db && npm i"
   },
   "dependencies": {
-    "@cofacts/media-manager": "^0.3.2",
+    "@cofacts/media-manager": "^0.3.3",
     "@elastic/elasticsearch": "^9.0.0",
     "@google-cloud/bigquery": "^6.2.0",
     "@google-cloud/vision": "^3.1.4",


### PR DESCRIPTION
## Summary

- Upgrade `@cofacts/media-manager` from 0.3.2 to 0.3.3.
- Fixes the `"No content-length provided"` error that the LINE bot hits when receiving images.

## Background

LINE's content API sometimes responds with chunked transfer encoding and no `Content-Length` header, which propagates through the `/getcontent` proxy. In 0.3.2, `prepareStream` threw when `content-length` was 0/missing. 0.3.3 (cofacts/media-manager#12) treats `size=0` as "unknown size" and simply skips the pre-resize step (resize only kicks in for `> 1MB`), which is the safe behavior.

## Test plan

- [ ] Deploy to production GCE (`rumors-deploy-line-bot-zh-1`)
- [ ] Send an image to the LINE bot and confirm no `"No content-length provided"` error
- [ ] Verify image article creation flow still works end-to-end

https://claude.ai/code/session_019Fod4zR5ehCU9MfBECHmTc

---
_Generated by [Claude Code](https://claude.ai/code/session_019Fod4zR5ehCU9MfBECHmTc)_