### PR TITLE
fix: count article replies from all apps toward user level

### DIFF
--- a/src/graphql/dataLoaders/repliedArticleCountLoaderFactory.js
+++ b/src/graphql/dataLoaders/repliedArticleCountLoaderFactory.js
@@ -20,7 +20,6 @@ export default () =>
                 bool: {
                   must: [
                     { term: { 'articleReplies.userId': userId } },
-                    { term: { 'articleReplies.appId': 'WEBSITE' } },
                     { term: { 'articleReplies.status': 'NORMAL' } },
                   ],
                 },

--- a/src/graphql/dataLoaders/userLevelLoaderFactory.js
+++ b/src/graphql/dataLoaders/userLevelLoaderFactory.js
@@ -18,7 +18,9 @@ export default () =>
      * @returns {Promise<LevelInfo[]>} - LevelInfo of each user
      */
     async (userIds) => {
-      // Currently "point" is defined as number of authored article replies.
+      // Currently "point" is defined as number of authored article replies,
+      // regardless of the app the article reply was submitted from --
+      // `articleReplies.userId` is already a globally unique DB user id.
       const searches = [];
       userIds.forEach((userId) => {
         searches.push({ index: 'articles' });
@@ -37,11 +39,6 @@ export default () =>
                         {
                           term: {
                             'articleReplies.userId': userId,
-                          },
-                        },
-                        {
-                          term: {
-                            'articleReplies.appId': 'WEBSITE',
                           },
                         },
                         {

--- a/src/graphql/queries/__fixtures__/GetUser.js
+++ b/src/graphql/queries/__fixtures__/GetUser.js
@@ -49,6 +49,23 @@ export default {
       { status: 'NORMAL', appId: 'WEBSITE', userId: 'other-user' },
     ],
   },
+  '/articles/doc/api-doc': {
+    articleReplies: [
+      // Article replies written through the GraphQL API without `x-app-id:
+      // RUMORS_SITE` are stamped with a non-WEBSITE appId, but still count
+      // toward the author's level & repliedArticleCount.
+      {
+        status: 'NORMAL',
+        appId: 'DEVELOPMENT_FRONTEND',
+        userId: 'current-user',
+      },
+      {
+        status: 'NORMAL',
+        appId: 'DEVELOPMENT_BACKEND',
+        userId: 'current-user',
+      },
+    ],
+  },
   '/articles/doc/not-this-doc': {
     articleReplies: [
       { status: 'DELETED', appId: 'WEBSITE', userId: 'current-user' },

--- a/src/graphql/queries/__fixtures__/GetUser.js
+++ b/src/graphql/queries/__fixtures__/GetUser.js
@@ -35,35 +35,28 @@ export default {
     avatarType: 'OpenPeeps',
     avatarData: '{"key":"value"}',
   },
+  // The appId of an article reply varies with the app it was submitted from,
+  // but has no effect on the author's level & repliedArticleCount.
   '/articles/doc/some-doc': {
     articleReplies: [
       // replies to the same doc only count as 1 for repliedArticleCount
       { status: 'NORMAL', appId: 'WEBSITE', userId: 'current-user' },
-      { status: 'NORMAL', appId: 'WEBSITE', userId: 'current-user' },
-      { status: 'NORMAL', appId: 'WEBSITE', userId: 'other-user' },
-    ],
-  },
-  '/articles/doc/another-doc': {
-    articleReplies: [
-      { status: 'NORMAL', appId: 'WEBSITE', userId: 'current-user' },
-      { status: 'NORMAL', appId: 'WEBSITE', userId: 'other-user' },
-    ],
-  },
-  '/articles/doc/api-doc': {
-    articleReplies: [
-      // Article replies written through the GraphQL API without `x-app-id:
-      // RUMORS_SITE` are stamped with a non-WEBSITE appId, but still count
-      // toward the author's level & repliedArticleCount.
       {
         status: 'NORMAL',
         appId: 'DEVELOPMENT_FRONTEND',
         userId: 'current-user',
       },
+      { status: 'NORMAL', appId: 'WEBSITE', userId: 'other-user' },
+    ],
+  },
+  '/articles/doc/another-doc': {
+    articleReplies: [
       {
         status: 'NORMAL',
         appId: 'DEVELOPMENT_BACKEND',
         userId: 'current-user',
       },
+      { status: 'NORMAL', appId: 'WEBSITE', userId: 'other-user' },
     ],
   },
   '/articles/doc/not-this-doc': {

--- a/src/graphql/queries/__tests__/__snapshots__/GetUser.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/GetUser.js.snap
@@ -5,14 +5,14 @@ Object {
   "data": Object {
     "GetUser": Object {
       "email": "hi@me.com",
-      "level": 4,
+      "level": 3,
       "name": "current user",
       "points": Object {
-        "currentLevel": 5,
-        "nextLevel": 8,
-        "total": 5,
+        "currentLevel": 3,
+        "nextLevel": 5,
+        "total": 3,
       },
-      "repliedArticleCount": 3,
+      "repliedArticleCount": 2,
       "votedArticleReplyCount": 3,
     },
   },

--- a/src/graphql/queries/__tests__/__snapshots__/GetUser.js.snap
+++ b/src/graphql/queries/__tests__/__snapshots__/GetUser.js.snap
@@ -5,14 +5,14 @@ Object {
   "data": Object {
     "GetUser": Object {
       "email": "hi@me.com",
-      "level": 3,
+      "level": 4,
       "name": "current user",
       "points": Object {
-        "currentLevel": 3,
-        "nextLevel": 5,
-        "total": 3,
+        "currentLevel": 5,
+        "nextLevel": 8,
+        "total": 5,
       },
-      "repliedArticleCount": 2,
+      "repliedArticleCount": 3,
       "votedArticleReplyCount": 3,
     },
   },


### PR DESCRIPTION
## Problem

In 2026-08-11 meeting, we found that a fact-checking collaborator who submits replies by calling the GraphQL API from a script has `level` stuck at 0 on their user page, even though the replies themselves are listed there.

`articleReply.appId` is set from `ctx.appId` (`src/util/user.ts:274` — website users have no `appId` field in their user doc, so the spread doesn't override it), and `ctx.appId` is only `'WEBSITE'` when the request carries `x-app-id: RUMORS_SITE` (`src/checkHeaders.js:29`). Anything else is `DEVELOPMENT_FRONTEND` (L46) or `DEVELOPMENT_BACKEND` (L13).

That split the same user's same replies across two inconsistent definitions:

| Path | Filter | Result |
|---|---|---|
| `ListArticles.articleRepliesFrom` (`queries/ListArticles.js:523-548`) | userId + status | visible |
| `contributionsLoaderFactory.js:24-52` | userId | visible |
| `moderation/blockUser.ts:57-103` | userId + status | affected |
| `userLevelLoaderFactory.js` | userId + status + **appId:'WEBSITE'** | 0 |
| `repliedArticleCountLoaderFactory.js` | userId + status + **appId:'WEBSITE'** | 0 |

## Why the filter existed, and why it can go

The `appId` term has been there since it was first written (`a03bc6b` / `ee2e8d3`, May 2018, #82 / #83). Neither the PRs nor the spec issues (#73 / #74, which say only "the level is determined by normal article reply count") give a reason — but back then a user *was* the `(userId, appId)` pair, so `userId` alone was not unique. See the header comment of `src/scripts/migrations/createBackendUsers.js`, which enumerates every index as referencing `(userId, appId)`.

That migration (`7521784`, Sept 2020) rewrote every `userId` in the DB into a globally unique DB user id via `getUserId()` / `convertAppUserIdToUserId()`. Since then the `appId` term has been redundant for identifying *who* wrote a reply — it only excludes valid contributions.

The `mcp` branch is about to make this worse: `09a1622` adds `appId: 'MCP'` and excludes it from `isBackendApp` precisely so MCP writes land on the user's existing social-login record, "letting appId remain 'MCP' in context for mutation attribution". Under the current filter every reply written through MCP would likewise earn no points. That is also why this PR drops the term outright rather than widening it to an allow-list — an allow-list would need a new entry for every client we add.

## Changes

- `src/graphql/dataLoaders/userLevelLoaderFactory.js` — drop the `articleReplies.appId` term from the nested agg filter; note the new definition in the comment.
- `src/graphql/dataLoaders/repliedArticleCountLoaderFactory.js` — same term dropped from the nested query.
- `src/graphql/queries/__fixtures__/GetUser.js` — the existing `current-user` article replies were 100% `WEBSITE`, so the suite would have passed either way. Two of them now carry `DEVELOPMENT_FRONTEND` / `DEVELOPMENT_BACKEND` instead, which asserts the point directly: **appId varies, the resulting numbers do not**. The snapshot is unchanged, and the pre-fix code fails this fixture (1 point instead of 3). The `DELETED` fixture in `not-this-doc` is untouched, so the `status` filter stays covered.

No other `appId` reads were touched — the remaining ones (`models/Article.js`, `models/ArticleReply.js`, `mutations/UpdateArticleReplyStatus.js`, `graphql/util.js`) are ownership/permission checks, not contribution stats.

## Notes

- **No data migration needed.** This is a read-path change, so existing users' levels correct themselves immediately. `articleReplies.appId` keeps its original value and remains an accurate record of which entry point a reply came in through.
- Users who contributed article replies via a backend app will see their level and points rise retroactively. The `LEVEL_POINTS` ladder in `util/level.js` is not being recalibrated.
- Fully reversible; nothing is written.

## Verification

- `npm run lint` clean on the changed files; `src/util/__tests__/level.js` passes.
- `GetUser` requires an Elasticsearch instance that wasn't available in my environment — **relying on CI for that suite.** The fixture change is designed to keep the snapshot identical, so a snapshot diff in CI means the reasoning above is wrong somewhere.
- The production diagnosis itself is still unverified — I had no access to production Elasticsearch. Worth confirming before deploy that the affected user's replies really are stamped non-`WEBSITE`:

  ```
  GET /articles/_search
  {
    "size": 0,
    "aggs": { "ar": { "nested": { "path": "articleReplies" },
      "aggs": { "mine": { "filter": { "bool": { "must": [
            { "term": { "articleReplies.userId": "-C5xiJ8BEY7yIwhpjOag" } },
            { "term": { "articleReplies.status": "NORMAL" } } ] } },
        "aggs": { "byApp": { "terms": { "field": "articleReplies.appId" } } } } } } }
  }
  ```

  `mine.doc_count` is the user's points after this change; `byApp` shows which appIds they were actually recorded under.