### PR TITLE
Handle URL resolve failures when creating replies

### DIFF
--- a/src/graphql/mutations/CreateReply.js
+++ b/src/graphql/mutations/CreateReply.js
@@ -97,6 +97,9 @@ export default {
     const scrapPromise = scrapUrls(`${text} ${reference}`, {
       cacheLoader: loaders.urlLoader,
       client,
+    }).catch(() => {
+      // Missing hyperlinks indicate loading, so persist an empty list on failure.
+      return [];
     });
 
     // Dependencies

--- a/src/graphql/mutations/__tests__/CreateReply.js
+++ b/src/graphql/mutations/__tests__/CreateReply.js
@@ -155,6 +155,57 @@ describe('CreateReply', () => {
     await client.delete({ index: 'replies', id: replyId });
   });
 
+  it('fills hyperlinks with an empty array when URL scraping fails', async () => {
+    const articleId = 'setReplyTest1';
+    const appId = 'url-scraping-failure-test';
+
+    try {
+      const { data, errors } = await gql`
+        mutation (
+          $articleId: String!
+          $text: String!
+          $type: ReplyTypeEnum!
+          $reference: String!
+        ) {
+          CreateReply(
+            articleId: $articleId
+            text: $text
+            type: $type
+            reference: $reference
+            waitForHyperlinks: true
+          ) {
+            id
+          }
+        }
+      `(
+        {
+          articleId,
+          text: 'URL scraping should fail',
+          type: 'RUMOR',
+          reference: 'http://scraping-should-fail.com',
+        },
+        { user: { id: 'test', appId } }
+      );
+
+      expect(errors).toBeUndefined();
+
+      const reply = await client.get({
+        index: 'replies',
+        id: data.CreateReply.id,
+      });
+
+      expect(reply._source.hyperlinks).toEqual([]);
+    } finally {
+      await client.indices.refresh({ index: 'replies' });
+      await client.deleteByQuery({
+        index: 'replies',
+        query: { term: { appId } },
+        refresh: true,
+      });
+      await resetFrom(fixtures, `/articles/doc/${articleId}`);
+    }
+  });
+
   it('should throw error since a reference is required for type !== NOT_ARTICLE', async () => {
     MockDate.set(1485593157011);
     const articleId = 'setReplyTest1';


### PR DESCRIPTION
## Summary

- recover URL scraping failures as an empty result when creating replies
- persist `hyperlinks: []` so clients stop polling after a resolver failure
- add a regression test that forces the failure path and always cleans up test data

## Root cause

`CreateReply` left the hyperlink update promise rejected when URL scraping failed. The reply therefore kept a missing `hyperlinks` field, which clients interpret as still loading.

## Validation

- `npm run lint` (passes with 6 existing warnings)
- `npm run typecheck`
- `jest src/graphql/mutations/__tests__/CreateReply.js --runInBand` (4 tests passed)
- `npm run posttest`
- Full local Jest run: 58 suites and 313 tests passed. Two GCS-gated integration files were reported as empty suites because local GCS credentials were not set.

Fixes #152
