### PR TITLE
fix: bound url-resolver gRPC calls with a deadline

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -117,6 +117,11 @@ GOOGLE_SHEETS_API_KEY=
 # URL to URL resolver microservice (http://github.com/cofacts/url-resolver)
 URL_RESOLVER_URL=localhost:4000
 
+# Max time (ms) to wait for URL resolver's gRPC response before giving up.
+# Without this, a hanging url-resolver call can outlive the request and cause
+# clients to receive a non-JSON error page instead of a GraphQL error. Default: 10000
+URL_RESOLVER_TIMEOUT_MS=
+
 # Apollo engine. When not given, disables Apollo Engine introspection
 ENGINE_API_KEY=
 

--- a/src/util/__tests__/grpc.js
+++ b/src/util/__tests__/grpc.js
@@ -1,0 +1,110 @@
+// Unlike scrapUrls.js's tests, this file exercises the *real* gRPC client
+// (src/util/__mocks__/grpc.js is intentionally not used here) against a throwaway
+// gRPC server, so it needs URL_RESOLVER_URL to point at that server *before*
+// `../grpc` is imported (the client is created at module load time).
+//
+// test/setup.js globally mocks this module for every test file; undo that here.
+jest.unmock('../grpc');
+
+const grpc = require('@grpc/grpc-js');
+const protoLoader = require('@grpc/proto-loader');
+
+const PROTO_PATH = __dirname + '/../protobuf/url_resolver.proto';
+const packageDefinition = protoLoader.loadSync(PROTO_PATH, {
+  keepCase: true,
+  longs: String,
+  enums: String,
+  defaults: true,
+  oneofs: true,
+});
+const urlResolverProto =
+  grpc.loadPackageDefinition(packageDefinition).url_resolver;
+
+/**
+ * Starts a throwaway UrlResolver gRPC server on a random free port.
+ * @param {(call) => void} onResolveUrl - handler for the ResolveUrl RPC
+ * @return {Promise<{server, port}>}
+ */
+function startFakeUrlResolverServer(onResolveUrl) {
+  const server = new grpc.Server();
+  server.addService(urlResolverProto.UrlResolver.service, {
+    ResolveUrl: onResolveUrl,
+  });
+  return new Promise((resolve, reject) => {
+    server.bindAsync(
+      '127.0.0.1:0',
+      grpc.ServerCredentials.createInsecure(),
+      (err, port) => {
+        if (err) return reject(err);
+        resolve({ server, port });
+      }
+    );
+  });
+}
+
+describe('grpc resolveUrl deadline', () => {
+  let server;
+
+  afterEach(() => {
+    if (server) {
+      server.forceShutdown();
+      server = null;
+    }
+    jest.resetModules();
+    delete process.env.URL_RESOLVER_URL;
+    delete process.env.URL_RESOLVER_TIMEOUT_MS;
+  });
+
+  it('rejects quickly instead of hanging when url-resolver never responds', async () => {
+    // Never call any of call.write()/call.end() -- simulates url-resolver hanging
+    // forever on a slow/misbehaving URL instead of erroring out or timing out itself.
+    const started = await startFakeUrlResolverServer(() => {});
+    server = started.server;
+
+    process.env.URL_RESOLVER_URL = `127.0.0.1:${started.port}`;
+    process.env.URL_RESOLVER_TIMEOUT_MS = '300';
+
+    let resolveUrl;
+    jest.isolateModules(() => {
+      resolveUrl = require('../grpc').default;
+    });
+
+    const startTime = Date.now();
+    await expect(resolveUrl(['http://example.com'])).rejects.toThrow(
+      /DEADLINE_EXCEEDED/
+    );
+    const elapsedMs = Date.now() - startTime;
+
+    // Well under both the old "hangs forever" behavior and Jest's own test timeout.
+    expect(elapsedMs).toBeLessThan(5000);
+  });
+
+  it('still resolves normally when url-resolver responds well within the deadline', async () => {
+    const started = await startFakeUrlResolverServer((call) => {
+      call.write({
+        url: 'http://example.com',
+        canonical: 'http://example.com',
+        title: 'Example',
+        summary: '',
+        top_image_url: '',
+        html: '',
+        status: 200,
+        successfully_resolved: true,
+      });
+      call.end();
+    });
+    server = started.server;
+
+    process.env.URL_RESOLVER_URL = `127.0.0.1:${started.port}`;
+    process.env.URL_RESOLVER_TIMEOUT_MS = '5000';
+
+    let resolveUrl;
+    jest.isolateModules(() => {
+      resolveUrl = require('../grpc').default;
+    });
+
+    const result = await resolveUrl(['http://example.com']);
+    expect(result).toHaveLength(1);
+    expect(result[0].title).toBe('Example');
+  });
+});

--- a/src/util/grpc.js
+++ b/src/util/grpc.js
@@ -20,10 +20,20 @@ const client = new urlResolverProto.UrlResolver(
   grpc.credentials.createInsecure()
 );
 
+// Without a deadline, a slow or hanging url-resolver (e.g. resolving a URL that
+// redirects through a lot of anti-bot / video-loading pages) can keep this call open
+// until an upstream gateway kills the connection, which returns an HTML/empty body
+// instead of JSON and breaks GraphQL clients trying to JSON.parse() the response.
+const URL_RESOLVER_TIMEOUT_MS =
+  Number(process.env.URL_RESOLVER_TIMEOUT_MS) || 10000;
+
 // Receiving stream response from resolver using gRPC
 export default (urls) =>
   new Promise((resolve, reject) => {
-    const call = client.ResolveUrl({ urls });
+    const call = client.ResolveUrl(
+      { urls },
+      { deadline: Date.now() + URL_RESOLVER_TIMEOUT_MS }
+    );
     const responses = [];
     call.on('data', (response) => {
       responses.push(response);


### PR DESCRIPTION
## What & why

Fixes #296. The reported "JSON parse error" isn't from `scrapUrls`/`grpc.js` itself failing badly — a fast connection failure to url-resolver already produces a normal, valid GraphQL error JSON. Instead, the issue's own screenshot of Rollbar (1626 occurrences, all TikTok short links) shows `node-fetch` in `rumors-line-bot` getting a response body starting with `<` — an HTML page, not JSON.

`src/util/grpc.js`'s `client.ResolveUrl({ urls })` call had no deadline at all. If url-resolver hangs while resolving a slow/redirect-heavy URL (TikTok short links go through several redirects and anti-bot pages), the GraphQL request just keeps waiting until an upstream gateway (proxy/PaaS router) kills the connection and returns its own HTML/empty error page — which is exactly what breaks `JSON.parse()` on the client.

## Fix

Add a `deadline` to the gRPC call, configurable via a new `URL_RESOLVER_TIMEOUT_MS` env var (default 10s, documented in `.env.sample`). When url-resolver doesn't answer in time, the existing `call.on('error', ...)` handler now fires with a `DEADLINE_EXCEEDED` error instead of the call hanging indefinitely — so `rumors-api` returns its own fast, well-formed GraphQL error well before any upstream gateway timeout would kick in.

## Verification

- Set up a native (Docker-free) Elasticsearch 9.3.2 test instance to run the full suite locally.
- New test (`src/util/__tests__/grpc.js`) spins up a real throwaway gRPC server (not the `__mocks__/grpc.js` stub used elsewhere) to verify both:
  - a url-resolver that never responds now rejects in ~0.3s (bounded by the deadline) instead of hanging, with a `DEADLINE_EXCEEDED` error.
  - a url-resolver that responds promptly still resolves normally — the deadline doesn't affect the happy path.
- Reproduced the original report's request shape end-to-end against a real local dev server (`ELASTICSEARCH_URL` + `URL_RESOLVER_URL` pointed at nothing) and confirmed the current code already returns valid JSON for a fast connection failure — the deadline specifically targets the *hang* case the Rollbar log shows, which isn't otherwise exercisable without a live, slow-to-resolve URL.
- Full suite: 356/356 passing (2 new, 0 changed elsewhere), `eslint` clean, `tsc --noEmit` clean.

## Note

This doesn't change `CreateReply.js`'s recent `.catch(() => [])` fallback (#398) — that's a separate, complementary improvement for one call site. This fix is at the shared `grpc.js` layer, so it also protects `ListArticles`, `ListReplies`, and `CreateArticle`, which don't currently catch a `scrapUrls` rejection.
